### PR TITLE
elpaca-repo-dir: fix string hosts

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -427,7 +427,7 @@ or nil if none apply."
          (pkg (plist-get recipe :package))
          (host (or (plist-get recipe :host) (plist-get recipe :fetcher)))
          (user nil)
-         (info (intern (concat url repo (and host (symbol-name host)))))
+         (info (intern (concat url repo (and host (if (symbolp host) (symbol-name host) host)))))
          (mono-repo (alist-get info elpaca--repo-dirs))
          (name (cond
                 (local-repo


### PR DESCRIPTION
I have one package from `:host "bitbucket.org"`, which doesn't work without this kind of change.

As a side note, the failure mode for this, at least with my config, was pretty nasty: Starting up Emacs just pops up an empty `*elpaca-log*` buffer. I debugged this by adding `(message "%s" elpaca)` at the bottom of `elpaca<-create` and trawling through the output, where I found the line with `failed nil Unable to determine repo dir: (wrong-type-argument symbolp "bitbucket.org")`.