### PR TITLE
Ensure dependency is not nil before getting its status

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1103,7 +1103,7 @@ If RECACHE is non-nil, do not use cached dependencies."
                     for d = (and (not (memq item elpaca-ignored-dependencies))
                                  (or (elpaca-alist-get item queued)
                                      (elpaca--queue item)))
-                    when (eq (elpaca--status d) 'queued)
+                    when (and d (eq (elpaca--status d) 'queued))
                     collect (prog1 d
                               (unless (memq item (elpaca<-dependencies e))
                                 (push item (elpaca<-dependencies e)))


### PR DESCRIPTION
I've found that when a dependency of an "E" is a member of `elpaca-ignored-dependencies`, `nil` will be passed as an argument to `elpaca--status`. This then causes a type error, which causes elpaca to fail. 

I'm a bit confused how I could be the first to come across this issue, as it seems to pretty reliably break even a minimal "default" elpaca configuration. In any case, this small change seems to fix the problem.