### PR TITLE
use-package integration: supports custom order

### DIFF
--- a/extensions/elpaca-use-package.el
+++ b/extensions/elpaca-use-package.el
@@ -34,10 +34,13 @@
   :type 'boolean :group 'elpaca)
 
 ;; Respects `:if', `:when', `:unless'
-(defun use-package-normalize/:elpaca (name _keyword args)
+(defun use-package-normalize/:elpaca (name keyword args)
   "Return `use-package' declaration with NAME's KEYWORD ARGS."
-  (let ((arg (car args)))
-    (if (and (listp arg) (keywordp (car arg))) (list (cons name arg)) args)))
+  (use-package-only-one (symbol-name keyword) args
+    (lambda (_label arg)
+      (if (keywordp (car-safe arg))
+          (cons name arg)
+        arg))))
 
 (defun use-package-handler/:elpaca (name _keyword args rest state)
   "Expand `use-package' declaration with NAME's body.
@@ -52,7 +55,7 @@ see `use-package' docs for STATE."
                         else collect el))
          (body (use-package-process-keywords name rest state))
          (arg (car args)))
-    `((elpaca ,@(if (eq t arg) (list name) args) ,@body))))
+    `((elpaca ,(if (eq t arg) name args) ,@body))))
 
 (defun elpaca-use-package--maybe (fn &rest args)
   "Temporarily disable `elpaca-use-package-mode' for FN with ARGS if :elpaca nil."


### PR DESCRIPTION
This PR allows setting custom order via `:elpaca` keyword in `use-package`.

E.g.,

```elisp
(use-package ace-link-dashboard
  :elpaca (:host github
           :repo "emacs-dashboard/ace-link-dashboard")
  :after dashboard
  :general (:keymaps 'dashboard-mode-map
            "o" 'ace-link-dashboard
            "d" 'ace-link-dashboard-remove))
```

Without this PR, it doesn't work properly.

In addition, this PR also makes sure that `:elpaca` accepts exactly one argument.
