### PR TITLE
elpaca-test.el: fix typo in elpaca-test docstring

### DIFF
--- a/elpaca-test.el
+++ b/elpaca-test.el
@@ -66,7 +66,7 @@
 ;;;###autoload
 (defmacro elpaca-test (&rest body)
   "Test Elpaca in a clean environment.
-BODY is psuedo plist which allows multiple values for certain keys.
+BODY is a pseudo-plist which allows multiple values for certain keys.
 The following keys are recognized:
   :name description of the test
 


### PR DESCRIPTION
<!-- -->
