### PR TITLE
add setup.el integration

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -184,6 +184,14 @@ This hook is run via `run-hook-with-args-until-success'."
                                             :repo "https://github.com/progfolio/elpaca.git"
                                             :files '("extensions/elpaca-use-package.el")
                                             :main "extensions/elpaca-use-package.el"
+                                            :build '(:not elpaca--compile-info))))
+		  (cons 'elpaca-setup
+                        (list :source "Elpaca extensions"
+                              :description "Elpaca setup.el support."
+                              :recipe (list :package "elpaca-setup"
+                                            :repo "https://github.com/progfolio/elpaca.git"
+                                            :files '("extensions/elpaca-setup.el")
+                                            :main "extensions/elpaca-setup.el"
                                             :build '(:not elpaca--compile-info))))))))
 
 (defcustom elpaca-menu-functions

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -25,6 +25,8 @@
 
 (require 'setup)
 
+;;; Code:
+
 (defun elpaca-setup--shorthand (sexp)
   "Retrieve feature from SEXP of :elpaca macro."
   (cadr sexp))
@@ -40,7 +42,7 @@
     orders))
 
 (defun elpaca-setup--extract-feat (name)
-  "Returns the feature from `NAME' of `setup' function."
+  "Return the feature from `NAME' of `setup' function."
   (if (consp name)
       (let ((shorthand (get (car name) 'setup-shorthand)))
 	(and shorthand (funcall shorthand name)))
@@ -49,7 +51,7 @@
 ;;;###autoload
 (defmacro elpaca-setup-integrate (use-elpaca-by-default)
   "Add `elpaca' support to `setup'.
-If USE-PACKAGE-BY-DEFAULT is t, then target feature in NAME of
+If USE-ELPACA-BY-DEFAULT is t, then target feature in NAME of
 `setup' will be used as ORDER to `elpaca' by appropriate
 shorthand of NAME unless there is no `:elpaca' call.
 
@@ -57,11 +59,11 @@ If there are multiple `:elpaca' calls, then their `elpaca' ORDER
 will be placed by the same order, top to bottom, as they seen.
 
 Only the first depth of `setup' BODY will be looked for `:elpaca'
-calls. Use `elpaca' directly or open a new `setup' block for
+calls.  Use `elpaca' directly or open a new `setup' block for
 other depths.
 
 Note that definition of `setup' will be replaced but previous
-definition will be in use under different name. So you should
+definition will be in use under different name.  So you should
 call `elpaca-setup-integrate' after user customizations to
 definition of `setup', such as advises."
   `(progn
@@ -80,8 +82,8 @@ This will help when chaining `:elpaca' with other `setup' constructs, such as `:
 				     (and (consp name)
 					  (or (and (eq :elpaca (car name)) (list (cdr name)))
 					      (elpaca-setup--find-orders name))))
-			     (and ,use-elpaca-by-default (list (elpaca-setup--extract-feat name))))) 
-		 (body `(elpaca ,(car orders) 
+			     (and ,use-elpaca-by-default (list (elpaca-setup--extract-feat name)))))
+		 (body `(elpaca ,(car orders)
 				(elpaca-setup--initial-setup-definition ,(elpaca-setup--extract-feat name) ; now use setup again for expanding body, but don't re-evaluate name again
 									,@body))))
 	   (progn
@@ -101,3 +103,7 @@ Note that `setup' definition will be restored to the one when
   (fset 'setup #'elpaca-setup--initial-setup-definition)
   (setq setup-macros (assoc-delete-all :elpaca setup-macros)))
 
+
+(provide 'elpaca-setup)
+
+;;; elpaca-setup.el ends here

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -25,7 +25,13 @@
 
 (require 'setup)
 
-(defvar elpaca-setup-feature-changer-constructs '(:with-feature))
+(defvar elpaca-setup-feature-changer-constructs '((:with-feature . (:get-feat #'cadr :get-body #'cddr)))
+  "Alist of keywords that change feature context of `setup'.
+Each element of alist must be in the form of (KEYWORD . PLIST)
+where PLIST must provide properties for `:get-feat' and
+`:get-body' both with a value of a function which when called
+with a sexp whose car is KEYWORD, returns the feature and body of
+the sexp respectively.")
 
 (defun elpaca-setup--shorthand (sexp)
   "Retrieve feature from SEXP of :elpaca macro."
@@ -44,43 +50,74 @@
       (setq lst (cdr lst)))
     order))
 
-(defun elpaca-setup--call-shorthand (name)
+(defun elpaca-setup--extract-feat (name)
+  "Returns the feature from `NAME' of `setup' function."
   (if (consp name)
       (let ((shorthand (get (car name) 'setup-shorthand)))
 	(and shorthand (funcall shorthand name)))
     name))
 
 (defun elpaca-setup--expand-feature-changer-constructs (body)
+  "Expand recursive :elpaca calls where encapsulating feature is possibly different.
+It is only meaningful to use `:elpaca' once for each different
+features. This is also because there is one function body for
+each different feature. This doesn't mean that you can't nest
+`elpaca' for continuing feature. You can still make use of
+`elpaca' function.
+
+Note that you can also nest `setup' constructs."
   (let (expanded-body)
     (dolist (e body)
-      (push (if-let (((memq (car-safe e) elpaca-setup-feature-changer-constructs))
-		     (order (elpaca-setup--find-order (cddr e))))
+      (push (if-let ((getters (alist-get (car-safe e) elpaca-setup-feature-changer-constructs))
+		     (order (elpaca-setup--find-order (funcall (plist-get getters :get-body) e))))
 		`(elpaca ,order
-			 (elpaca-setup--setup-initial-definition ,(cadr e)
+			 (elpaca-setup--setup-initial-definition ,(funcall (plist-get getters :get-feat) e)
 								 ,@(elpaca-setup--expand-feature-changer-constructs (cddr e))))
 	      e)
 	    expanded-body))
     (nreverse expanded-body)))
 
 (defmacro elpaca-setup--default-dependent-order-condition (use-elpaca-by-default name)
+  "Returns the predicate for extracting order from NAME.
+If USE-PACKAGE-BY-DEFAULT is t, then target feature in NAME of
+`setup' will be used as ORDER to `elpaca' by appropriate
+shorthand of NAME."
   (if use-elpaca-by-default
       `(or (and (consp ,name)
 		(or (and (eq :elpaca (car ,name)) (cdr ,name))
 		    (elpaca-setup--find-order ,name)))
-	   (elpaca-setup--call-shorthand ,name))
+	   (elpaca-setup--extract-feat ,name))
     `(and (consp ,name)
 	  (or (and (eq :elpaca (car ,name)) (cdr ,name))
 	      (elpaca-setup--find-order ,name)))))
 
 ;;;###autoload
 (defmacro elpaca-setup-integrate (use-elpaca-by-default)
+  "Add `elpaca' support to `setup'.
+If USE-PACKAGE-BY-DEFAULT is t, then target feature in NAME of
+`setup' will be used as ORDER to `elpaca' by appropriate
+shorthand of NAME.
+
+If `:elpaca' exists in both NAME and BODY of `setup', then the
+one in BODY will be selected which helps you to override `elpaca'
+ORDER if USE-ELPACA-BY-DEFAULT is t.
+
+If there are multiple `:elpaca' exists at same depth of BODY of
+`setup', first one will be chosen. See
+`elpaca-setup--expand-feature-changer-constructs' for details.
+
+Note that definition of `setup' will be replaced but previous
+definition will be in use under different name. So you should
+call `elpaca-setup-integrate' after user customizations to
+definition of `setup', such as advises."
   `(progn
-     (fset 'elpaca-setup--setup-initial-definition (symbol-function #'setup))
+     (fset 'elpaca-setup--setup-initial-definition (or setup-definition (symbol-function #'setup)))
      (put 'elpaca-setup--setup-initial-definition 'lisp-indent-function 1)
      
      (setup-define :elpaca
        (lambda (&rest _) t)
-       :documentation "A placeholder SETUP macro that evaluates to t."
+       :documentation "A placeholder SETUP macro that evaluates to t.
+This will help when chaining `:elpaca' with other `setup' constructs, such as `:and'."
        :shorthand #'elpaca-setup--shorthand)
 
      (defmacro setup (name &rest body)
@@ -88,17 +125,20 @@
        (if-let ((order (or (elpaca-setup--find-order body)
 			   (elpaca-setup--default-dependent-order-condition ,use-elpaca-by-default name))))
 	   `(elpaca-setup--setup-initial-definition ,name
-			       (elpaca ,order
-				       (elpaca-setup--setup-initial-definition ,(if (consp order)
-							       (car order)
-							     order)
-							  ,@(elpaca-setup--expand-feature-changer-constructs body))))
+						    (elpaca ,order
+							    (elpaca-setup--setup-initial-definition ,(if (consp order)
+													 (car order)
+												       order)
+												    ,@(elpaca-setup--expand-feature-changer-constructs body))))
 	 `(elpaca-setup--setup-initial-definition ,name ,@(elpaca-setup--expand-feature-changer-constructs body))))
 
      (put #'setup 'function-documentation (advice--make-docstring 'elpaca-setup--setup-initial-definition))))
 
 ;;;###autoload
 (defun elpaca-setup-teardown ()
+  "Remove `elpaca' support from `setup'.
+Note that `setup' definition will be restored to the one when
+`elpaca-setup-integrate' is called."
   (fset 'setup #'elpaca-setup--setup-initial-definition)
   (setq setup-macros (assoc-delete-all :elpaca setup-macros)))
 

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -25,7 +25,7 @@
 
 (require 'setup)
 
-(defvar elpaca-setup-feature-changer-constructs '((:with-feature . (:get-feat #'cadr :get-body #'cddr)))
+(defvar elpaca-setup-feature-changer-constructs '((:with-feature . (:get-feat cadr :get-body cddr)))
   "Alist of keywords that change feature context of `setup'.
 Each element of alist must be in the form of (KEYWORD . PLIST)
 where PLIST must provide properties for `:get-feat' and

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -66,8 +66,8 @@ definition will be in use under different name. So you should
 call `elpaca-setup-integrate' after user customizations to
 definition of `setup', such as advises."
   `(progn
-     (fset 'elpaca-setup--setup-initial-definition (symbol-function #'setup))
-     (put 'elpaca-setup--setup-initial-definition 'lisp-indent-function 1)
+     (fset 'elpaca-setup--initial-setup-definition (symbol-function #'setup))
+     (put 'elpaca-setup--initial-setup-definition 'lisp-indent-function 1)
      
      (setup-define :elpaca
        (lambda (&rest _) t)
@@ -83,22 +83,22 @@ This will help when chaining `:elpaca' with other `setup' constructs, such as `:
 					      (elpaca-setup--find-orders name))))
 			     (and ,use-elpaca-by-default (list (elpaca-setup--extract-feat name))))) 
 		 (body `(elpaca ,(car orders) 
-				(elpaca-setup--setup-initial-definition ,(elpaca-setup--extract-feat name) ; now use setup again for expanding body, but don't re-evaluate name again
+				(elpaca-setup--initial-setup-definition ,(elpaca-setup--extract-feat name) ; now use setup again for expanding body, but don't re-evaluate name again
 									,@body))))
 	   (progn
 	     (dolist (order (cdr orders))
 	       (setq body `(elpaca ,order ,body)))
-	     `(elpaca-setup--setup-initial-definition ,name ; setup may be shortcircuited
+	     `(elpaca-setup--initial-setup-definition ,name ; setup short-circuit may occur
 						      ,body))
-	 `(elpaca-setup--setup-initial-definition ,name ,@body))) ; no :elpaca, normal setup
+	 `(elpaca-setup--initial-setup-definition ,name ,@body))) ; no :elpaca, normal setup
 
-     (put #'setup 'function-documentation (advice--make-docstring 'elpaca-setup--setup-initial-definition))))
+     (put #'setup 'function-documentation (advice--make-docstring 'elpaca-setup--initial-setup-definition))))
 
 ;;;###autoload
 (defun elpaca-setup-teardown ()
   "Remove `elpaca' support from `setup'.
 Note that `setup' definition will be restored to the one when
 `elpaca-setup-integrate' is called."
-  (fset 'setup #'elpaca-setup--setup-initial-definition)
+  (fset 'setup #'elpaca-setup--initial-setup-definition)
   (setq setup-macros (assoc-delete-all :elpaca setup-macros)))
 

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -51,15 +51,14 @@
   "Add `elpaca' support to `setup'.
 If USE-PACKAGE-BY-DEFAULT is t, then target feature in NAME of
 `setup' will be used as ORDER to `elpaca' by appropriate
-shorthand of NAME.
+shorthand of NAME unless there is no `:elpaca' call.
 
-If `:elpaca' exists in both NAME and BODY of `setup', then the
-one in BODY will be selected which helps you to override `elpaca'
-ORDER if USE-ELPACA-BY-DEFAULT is t.
+If there are multiple `:elpaca' calls, then their `elpaca' ORDER
+will be placed by the same order, top to bottom, as they seen.
 
-If there are multiple `:elpaca' exists in BODY of `setup', first
-one will be chosen. If required so, use `elpaca' directly, or
-open a new `setup' inside.
+Only the first depth of `setup' BODY will be looked for `:elpaca'
+calls. Use `elpaca' directly or open a new `setup' block for
+other depths.
 
 Note that definition of `setup' will be replaced but previous
 definition will be in use under different name. So you should

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -1,0 +1,89 @@
+;;; elpaca-setup.el --- Elpaca setup.el support -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023 Sami Batuhan Basmaz Ölmez
+
+;; Author: Sami Batuhan Basmaz Ölmez
+;; URL: https://github.com/progfolio/elpaca
+;; Package-Requires: ((emacs "27.1") (elpaca "0") (setup "1.3.2"))
+;; Version: 0.0.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; setup.el support for Elpaca
+
+(require 'setup)
+
+(defun elpaca-setup--shorthand (sexp)
+  "Retrieve feature from SEXP of :elpaca macro."
+  (let ((order (cadr sexp)))
+    (if (consp order)
+        (car order)
+      order)))
+
+(defun elpaca-setup--find-order (lst)
+  "Find :elpaca setup macro in LST and return ELPACA ORDER."
+  (let (order)
+    (while (and lst (not order))
+      (if (and (consp (car lst))
+	       (eq (caar lst) :elpaca))
+	  (setq order (cdar lst)))
+      (setq lst (cdr lst)))
+    order))
+
+(defun elpaca-setup--call-shorthand (name)
+  (if (consp name)
+      (let ((shorthand (get (car name) 'setup-shorthand)))
+	(and shorthand (funcall shorthand name)))
+    name))
+
+(defmacro elpaca-setup--default-dependent-order-condition (use-elpaca-by-default name)
+  (if use-elpaca-by-default
+      `(or (and (consp ,name)
+		(or (and (eq :elpaca (car ,name)) (cdr ,name))
+		    (elpaca-setup--find-order ,name)))
+	   (elpaca-setup--call-shorthand ,name))
+    `(and (consp ,name)
+	  (or (and (eq :elpaca (car ,name)) (cdr ,name))
+	      (elpaca-setup--find-order ,name)))))
+
+;;;###autoload
+(defmacro elpaca-setup-integrate (use-elpaca-by-default)
+  `(progn
+     (fset 'elpaca-setup--setup-initial-definition (symbol-function #'setup))
+     
+     (setup-define :elpaca
+       (lambda (&rest _) t)
+       :documentation "A placeholder SETUP macro that evaluates to t."
+       :shorthand #'elpaca-setup--shorthand)
+
+     (defmacro setup (name &rest body)
+       (declare (indent 1))
+       (if-let ((order (or (elpaca-setup--find-order body)
+			   (elpaca-setup--default-dependent-order-condition ,use-elpaca-by-default name))))
+	   `(elpaca-setup--setup-initial-definition ,name
+			       (elpaca ,order
+				       (elpaca-setup--setup-initial-definition ,(if (consp order)
+							       (car order)
+							     order)
+							  ,@body)))
+	 `(elpaca-setup--setup-initial-definition ,name ,@body)))
+
+     (put #'setup 'function-documentation (advice--make-docstring 'elpaca-setup--setup-initial-definition))))
+
+;;;###autoload
+(defun elpaca-setup-teardown ()
+  (fset 'setup #'elpaca-setup--setup-initial-definition)
+  (setq setup-macros (assoc-delete-all :elpaca setup-macros)))
+

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -27,10 +27,7 @@
 
 (defun elpaca-setup--shorthand (sexp)
   "Retrieve feature from SEXP of :elpaca macro."
-  (let ((order (cadr sexp)))
-    (if (consp order)
-        (car order)
-      order)))
+  (cadr sexp))
 
 (defun elpaca-setup--find-order (lst)
   "Find :elpaca setup macro in LST and return ELPACA ORDER."

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -98,9 +98,7 @@ This will help when chaining `:elpaca' with other `setup' constructs, such as `:
 			   (elpaca-setup--default-dependent-order-condition ,use-elpaca-by-default name))))
 	   `(elpaca-setup--setup-initial-definition ,name ; setup may be shortcircuited
 						    (elpaca ,order ; place order
-							    (elpaca-setup--setup-initial-definition ,(if (consp order) ; now use setup again for expanding body, but don't re-evaluate name again
-													 (car order)
-												       order)
+							    (elpaca-setup--setup-initial-definition ,(elpaca-setup--extract-feat name) ; now use setup again for expanding body, but don't re-evaluate name again
 												    ,@body)))
 	 `(elpaca-setup--setup-initial-definition ,name ,@body))) ; no :elpaca, normal setup
 

--- a/extensions/elpaca-setup.el
+++ b/extensions/elpaca-setup.el
@@ -111,7 +111,7 @@ definition will be in use under different name. So you should
 call `elpaca-setup-integrate' after user customizations to
 definition of `setup', such as advises."
   `(progn
-     (fset 'elpaca-setup--setup-initial-definition (or setup-definition (symbol-function #'setup)))
+     (fset 'elpaca-setup--setup-initial-definition (symbol-function #'setup))
      (put 'elpaca-setup--setup-initial-definition 'lisp-indent-function 1)
      
      (setup-define :elpaca


### PR DESCRIPTION
Bootstrap code,

```elisp
;;; elpaca.el -*- lexical-binding: t; -*-

;;; Elpaca installer script

(setq package-enable-at-startup nil)

(defvar elpaca-installer-version 0.4)
(defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
(defvar elpaca-repos-directory (expand-file-name "repos/" elpaca-directory))
(defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                              :ref nil
                              :files (:defaults (:exclude "extensions"))
                              :build (:not elpaca--activate-package)))

(when-let ((repo  (expand-file-name "elpaca/" elpaca-repos-directory))
           (build (expand-file-name "elpaca/" elpaca-builds-directory))
           (order (cdr elpaca-order))
           ((add-to-list 'load-path (if (file-exists-p build) build repo)))
           ((not (file-exists-p repo))))
  (condition-case-unless-debug err
      (if-let ((buffer (pop-to-buffer-same-window "*elpaca-installer*"))
               ((zerop (call-process "git" nil buffer t "clone"
                                     (plist-get order :repo) repo)))
               (default-directory repo)
               ((zerop (call-process "git" nil buffer t "checkout"
                                     (or (plist-get order :ref) "--"))))
               (emacs (concat invocation-directory invocation-name))
               ((zerop (call-process emacs nil buffer nil "-Q" "-L" "." "--batch"
                                     "--eval" "(byte-recompile-directory \".\" 0 'force)"))))
          (progn (require 'elpaca)
                 (elpaca-generate-autoloads "elpaca" repo)
                 (kill-buffer buffer))
        (error "%s" (with-current-buffer buffer (buffer-string))))
    ((error) (warn "%s" err) (delete-directory repo 'recursive))))

(require 'elpaca-autoloads)

(add-hook 'after-init-hook #'elpaca-process-queues)

(elpaca `(,@elpaca-order))

(elpaca (elpaca-setup
	 :host github
	 :repo "repelliuss/elpaca"
	 :branch "setup.el"
	 :files ("extensions/elpaca-setup.el")
	 :main "extensions/elpaca-setup.el"
	 :build (:not elpaca--compile-info))
	(elpaca-setup-integrate 'use-by-default))

(elpaca-wait)
```

`setup` defined as,

```elisp
(defmacro setup (name &rest body)
  "Configure feature or subsystem NAME.
BODY may contain special forms defined by `setup-define', but
will otherwise just be evaluated as is.
NAME may also be a macro, if it can provide a symbol."
  ...)
```

`elpaca-setup-integrate` defined as,

```elisp
(defmacro elpaca-setup-integrate (use-elpaca-by-default)
  "Add `elpaca' support to `setup'.
If USE-ELPACA-BY-DEFAULT is t, then target feature in NAME of
`setup' will be used as ORDER to `elpaca' by appropriate
shorthand of NAME unless there is no `:elpaca' call.

If there are multiple `:elpaca' calls, then their `elpaca' ORDER
will be placed by the same order, top to bottom, as they seen.

Only the first depth of `setup' BODY will be looked for `:elpaca'
calls. Use `elpaca' directly or open a new `setup' block for
other depths.

Note that definition of `setup' will be replaced but previous
definition will be in use under different name. So you should
call `elpaca-setup-integrate' after user customizations to
definition of `setup', such as advises."
...)
```

Related issues are #7, #58, #68.

If `use-by-default` is `t`, then any call of `:elpaca` will override default `ORDER` which is feature extracted by calling `setup` shorthand for `NAME`. That way, one can avoid installing a package by using `(:elpaca nil)` in `BODY`.

How integration works is simply wrapping `setup` block inside `elpaca` block but that being in outer `setup` block due to `NAME` may contain a conditional which should be checked against before installing the package. For example,

```elisp
(setup (:if-feature 'a-feat-does-not-exist)
  (:elpaca foo)
  (defvar boo 3))
```

would expand to something like this,

```elisp
(setup (:if-feature a-feat-does-not-exist)
  (elpaca foo
     (setup a-feat-does-not-exist
        (defvar boo 3))))
```

If there were `:elpaca` calls in `BODY`, they would wrap inner `setup` in the order they seen.

Now, outer `setup` evaluates conditions, the real configuration is wrapped inside `elpaca`, second `setup` is needed again since it is still a `setup` special body. This works by replacing `setup` definition and using its replaced function definition instead to avoid infinite recursion. Also, `:elpaca` calls are not removed. They just evaluate to `t` which is useful for chaining in conditionals, i.e `:and` macro.

The reason only the first depth of `BODY` being looked for `:elpaca` calls is just that they are not meaningful otherwise. Users of `setup` can still make use of `elpaca` as described. Even if there is a useful case, which I'm open to learn and provide a solution then, there are questions like which `setup` macros are meaningful to search for and user even possibly can define others, where is the body of that macro and should that `:elpaca` call wrap that macro or merged into the top level ones.

Multiple `:elpaca` calls in `BODY` is also arguable but I read an attempt [here](https://github.com/progfolio/elpaca/issues/58#issuecomment-1411036871) and chose to add support.