### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 # Build with: docker build --build-arg VERSION=NN.N -t elpaca-NN.N .
-# Add --nocache arg to force init regeneration.
+# Add --no-cache arg to force init regeneration.
 ARG VERSION
 FROM silex/emacs:$VERSION-ci
-ARG REF=nil
 RUN useradd --create-home --shell /bin/bash docker
 USER docker
-WORKDIR /home/docker
-RUN mkdir -p .emacs.d/
 WORKDIR /home/docker/.emacs.d/
-RUN echo "(setq package-enable-at-startup nil)" > early-init.el
-RUN curl "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/init.el" > init.el
+RUN curl --remote-name-all \
+    "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/early-init.el" \
+    "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/init.el"
+ARG REF=nil
 RUN sed -i "s|:ref nil|:ref ${REF}|g" init.el


### PR DESCRIPTION

This pull request introduces several optimizations to the Dockerfile:

1. Corrected `docker build` Argument: The `--nocache` argument has been corrected to `--no-cache`.

2. Simplified Directory Creation: The explicit creation of the `.emacs.d/` directory has been removed. The `WORKDIR` instruction creates the specified directory if it does not exist.

3. Streamlined File Download: The separate `RUN` instructions for creating `early-init.el` and downloading `init.el` have been combined into a single `RUN` instruction using `curl --remote-name-all`.

4. Optimized Docker Layer Caching: The `ARG REF=nil` instruction has been moved just before its usage in the `sed` command. This helps to avoid unnecessary downloads when building the Docker image. Please see the tests below for more detailed information.

<details>

<summary>Tests</summary>

In order to validate these optimizations, a series of tests will be conducted. The tests will be performed twice for both the original and optimized Dockerfile, totaling four test runs.

1. The first test run will build the Docker image normally using the `--no-cache` option.

2. The second test run will build the Docker image with a specified `REF` value. This will test the Docker layer caching behavior and verify if unnecessary downloads are avoided when the `REF` value changes.

Tests with original Dockerfile:

```
user $ docker build --build-arg VERSION=29.2 -t elpaca-29.2 --no-cache .
[+] Building 19.7s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 548B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                              0.1s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/silex/emacs:29.2-ci                                                                                                                                                 2.5s
 => [1/8] FROM docker.io/silex/emacs:29.2-ci@sha256:747b9ce34f9af4030be66299554610facda2aa781f9f2d52d56db80f6418a7d3                                                                                          14.5s
 (snip)
 => [2/8] RUN useradd --create-home --shell /bin/bash docker                                                                                                                                                   0.7s
 => [3/8] WORKDIR /home/docker                                                                                                                                                                                 0.0s
 => [4/8] RUN mkdir -p .emacs.d/                                                                                                                                                                               0.2s
 => [5/8] WORKDIR /home/docker/.emacs.d/                                                                                                                                                                       0.0s
 => [6/8] RUN echo "(setq package-enable-at-startup nil)" > early-init.el                                                                                                                                      0.2s
 => [7/8] RUN curl "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/init.el" > init.el                                                                                                           0.9s
 => [8/8] RUN sed -i "s|:ref nil|:ref nil|g" init.el                                                                                                                                                           0.2s
 => exporting to image                                                                                                                                                                                         0.2s
 => => exporting layers                                                                                                                                                                                        0.2s
 => => writing image sha256:174b92eebb95ec07d03341a5d48dea8b4039eca51ac204e20d3ca8f901dc93f3                                                                                                                   0.0s
 => => naming to docker.io/library/elpaca-29.2                                                                                                                                                                 0.0s

user $ docker build --build-arg VERSION=29.2 -t elpaca-29.2 --build-arg REF=\"6bbc174\" .
[+] Building 2.4s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 548B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/silex/emacs:29.2-ci                                                                                                                                                 0.8s
 => CACHED [1/8] FROM docker.io/silex/emacs:29.2-ci@sha256:747b9ce34f9af4030be66299554610facda2aa781f9f2d52d56db80f6418a7d3                                                                                    0.0s
 => [2/8] RUN useradd --create-home --shell /bin/bash docker                                                                                                                                                   0.3s
 => [3/8] WORKDIR /home/docker                                                                                                                                                                                 0.0s
 => [4/8] RUN mkdir -p .emacs.d/                                                                                                                                                                               0.2s
 => [5/8] WORKDIR /home/docker/.emacs.d/                                                                                                                                                                       0.0s
 => [6/8] RUN echo "(setq package-enable-at-startup nil)" > early-init.el                                                                                                                                      0.2s
 => [7/8] RUN curl "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/init.el" > init.el                                                                                                           0.4s
 => [8/8] RUN sed -i "s|:ref nil|:ref "6bbc174"|g" init.el                                                                                                                                                     0.2s
 => exporting to image                                                                                                                                                                                         0.1s
 => => exporting layers                                                                                                                                                                                        0.1s
 => => writing image sha256:e74fc5d8e7fc140123bb3eb1b7cd54e66431b4d8b26bc2ef457d86704adc8973                                                                                                                   0.0s
 => => naming to docker.io/library/elpaca-29.2                                                                                                                                                                 0.0s
```

The following commands are used to remove the built image and prune the system:

```
user $ docker image rm elpaca-29.2
user $ docker image prune
user $ docker builder prune
```

Tests with optimized Dockerfile:

```
user $ docker build --build-arg VERSION=29.2 -t elpaca-29.2 --no-cache .
[+] Building 19.3s (9/9) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                              0.1s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.1s
 => => transferring dockerfile: 539B                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/silex/emacs:29.2-ci                                                                                                                                                 1.7s
 => [1/5] FROM docker.io/silex/emacs:29.2-ci@sha256:747b9ce34f9af4030be66299554610facda2aa781f9f2d52d56db80f6418a7d3                                                                                          15.7s
 (snip)
 => [2/5] RUN useradd --create-home --shell /bin/bash docker                                                                                                                                                   0.8s
 => [3/5] WORKDIR /home/docker/.emacs.d/                                                                                                                                                                       0.0s
 => [4/5] RUN curl --remote-name-all     "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/early-init.el"     "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/init.el"             0.6s
 => [5/5] RUN sed -i "s|:ref nil|:ref nil|g" init.el                                                                                                                                                           0.3s
 => exporting to image                                                                                                                                                                                         0.1s
 => => exporting layers                                                                                                                                                                                        0.1s
 => => writing image sha256:a01d178af1aef6957782e546dc4b6584549d3ee77bb93ab185091e70a7adfb29                                                                                                                   0.0s
 => => naming to docker.io/library/elpaca-29.2                                                                                                                                                                 0.0s

user $ docker build --build-arg VERSION=29.2 -t elpaca-29.2 --build-arg REF=\"6bbc174\" .
[+] Building 0.6s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 539B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/silex/emacs:29.2-ci                                                                                                                                                 0.3s
 => [1/5] FROM docker.io/silex/emacs:29.2-ci@sha256:747b9ce34f9af4030be66299554610facda2aa781f9f2d52d56db80f6418a7d3                                                                                           0.0s
 => CACHED [2/5] RUN useradd --create-home --shell /bin/bash docker                                                                                                                                            0.0s
 => CACHED [3/5] WORKDIR /home/docker/.emacs.d/                                                                                                                                                                0.0s
 => CACHED [4/5] RUN curl --remote-name-all     "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/early-init.el"     "https://raw.githubusercontent.com/progfolio/elpaca/master/doc/init.el"      0.0s
 => [5/5] RUN sed -i "s|:ref nil|:ref "6bbc174"|g" init.el                                                                                                                                                     0.2s
 => exporting to image                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                        0.0s
 => => writing image sha256:de49dacbf1bcfff541f200e59604ca4bf9ced8828ab2dd568d9bad601aa47e8d                                                                                                                   0.0s
 => => naming to docker.io/library/elpaca-29.2                                                                                                                                                                 0.0s
```

The optimized Dockerfile has been confirmed to effectively utilize caching.

</details>

I hope you find this change to be to your liking. Thank you for considering my pull request.
