### PR TITLE
Consider ELPA's manual-sync repositories as a developed in ELPA

### DIFF
--- a/elpaca-menu-elpa.el
+++ b/elpaca-menu-elpa.el
@@ -107,7 +107,7 @@
        (((or core (if releasep (plist-get props :release-branch) t)))
         (name (symbol-name id))
         (url (or (and core elpaca-menu-elpa-emacs-url)
-                 (and manual-sync remote)
+                 (and (plist-get props :manual-sync) remote) ;; developed in ELPA repo
                  (if-let ((declared (plist-get props :url))
                           ;;Why does ELPA keep the :url when upstream is gone?
                           ((not (or releasep (string-match-p elpaca-menu-elpa-ignored-url-regexp declared)))))

--- a/elpaca-menu-elpa.el
+++ b/elpaca-menu-elpa.el
@@ -98,7 +98,6 @@
    with branch-prefix = (alist-get 'branch-prefix elpa)
    for (id . props) in (elpaca-menu-elpa--recipes elpa)
    for core = (plist-get props :core)
-   for manual-sync = (plist-get props :manual-sync)
    when core do
    (setq core (mapcar (lambda (f) (if (equal f (file-name-as-directory f)) (concat f "*") f))
                       (if (listp core) core (list core))))

--- a/elpaca-menu-elpa.el
+++ b/elpaca-menu-elpa.el
@@ -98,6 +98,7 @@
    with branch-prefix = (alist-get 'branch-prefix elpa)
    for (id . props) in (elpaca-menu-elpa--recipes elpa)
    for core = (plist-get props :core)
+   for manual-sync = (plist-get props :manual-sync)
    when core do
    (setq core (mapcar (lambda (f) (if (equal f (file-name-as-directory f)) (concat f "*") f))
                       (if (listp core) core (list core))))
@@ -106,6 +107,7 @@
        (((or core (if releasep (plist-get props :release-branch) t)))
         (name (symbol-name id))
         (url (or (and core elpaca-menu-elpa-emacs-url)
+                 (and manual-sync remote)
                  (if-let ((declared (plist-get props :url))
                           ;;Why does ELPA keep the :url when upstream is gone?
                           ((not (or releasep (string-match-p elpaca-menu-elpa-ignored-url-regexp declared)))))


### PR DESCRIPTION
# Foreword

I hope this pull-request finds you well. Thank you for all of the time
and support on my previous issues. I continued looking into some
issues I encountered and figured that I could perhaps propose an
improvement.

I'm unsure what the longterm plans are with this package but I do have
signed FSF papers in case that is a requirement for contribution.

# Background

There are many Elpa packages that when downloaded through package.el
have different content compared to when they are downloaded through
Elpaca. An example of this is the [chess package](https://git.savannah.gnu.org/cgit/emacs/elpa.git/tree/elpa-packages?h=main#n145) or the [bbdb package](https://git.savannah.gnu.org/cgit/emacs/elpa.git/tree/elpa-packages?h=main#n89).

Looking at these packages we can see that they use the `manual-sync t`
setting.  This setting in `elpa-packages` indicates that the package
is actually manually synced into the Elpa repository and that the
"source of truth" is in Elpa and not the remote repository. When
Elpa builds a tarball for such a package it uses the Elpa repository
not the remote repository.

It seems like the main reasons for the existence of this flag can be seen
in a comment in the chess recipe:
```
;; FIXME: The two versions are badly out of sync.
```
This flag allows Elpa developers to maintain a package in the Elpa
repository while still keeping a reference to the upstream.

# Problem

Elpaca does not handle these manual-sync packages in the same way as
Elpa expects them to be handled. Elpaca ignores the `manual-sync t`
setting and downloads the package from the upstream repository. This
is a problem because Elpaca downloads a different package than Elpa
intends to expose.

# Solution

If an Elpa package uses `manual-sync t` Elpaca should install it from
the relevant branch in the Elpa repository instead of from the
upstream.

# Implementation

I modified the `elpaca-menu-elpa--index` to handle this `manual-sync`
setting and choose a different URL in that case.

# Testing

To test that this works correctly I figured I would look at a recipe
before and after my change. Note that I've also tested that installing
works properly but that isn't very relevant since I haven't changed
anything there.

The most minimal test I could come up with was to look at the recipe:
```elisp
(prog1
    (let ((elpaca-menu-functions '(elpaca-menu-gnu-devel-elpa)))
      (elpaca-update-menus)
      (elpaca-recipe 'chess))
  (elpaca-update-menus))
```  

**Before my change**:
```
(:package "chess" 
 :repo "https://github.com/jwiegley/emacs-chess.git" 
 :local-repo "chess" 
 :files ("*" (:exclude ".git")) 
 :source "GNU-devel ELPA" 
 :protocol https ...)
```

**After my change**: 
```
(:package "chess" 
 :repo "git://git.sv.gnu.org/emacs/elpa" 
 :local-repo "chess" 
 :branch "externals/chess" 
 :files ("*" (:exclude ".git")) 
 :source "GNU-devel ELPA" ...)
```

We can see that after my change the intended branch is selected