### PR TITLE
Make tags work reliably as version info

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1172,8 +1172,11 @@ The keyword's value is expected to be one of the following:
                     (error "Unable to find main elisp file for %S" package)))))))
 
 (defvar elpaca--tag-regexp
-  "\\`\\(?:\\|[vVrR]\\|\\(?:release\\|%p\\)[-/]v?\\)?\
-\\(?1:[0-9]+\\(\\.[0-9]+\\)*\\)\\'")
+  (rx bos (opt (or "" (any "RVrv") (seq "release" (any "/-") (opt "v"))))
+      (group-n 1
+        (one-or-more (any "0-9"))
+        (zero-or-more (group "." (one-or-more (any "0-9")))))
+      eos))
 (defun elpaca-latest-tag (e)
   "Return E's latest merged tag matching recipe tag regexp or `elpaca--tag-regexp'."
   (when-let ((default-directory (elpaca<-repo-dir e))

--- a/elpaca.el
+++ b/elpaca.el
@@ -1171,7 +1171,9 @@ The keyword's value is expected to be one of the following:
                           (elpaca--directory-files-recursively repo (concat "\\`[^.z-a]*" name))))
                     (error "Unable to find main elisp file for %S" package)))))))
 
-(defvar elpaca--tag-regexp "\\(?:v?\\([[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+\\)\\)")
+(defvar elpaca--tag-regexp
+  "\\`\\(?:\\|[vVrR]\\|\\(?:release\\|%p\\)[-/]v?\\)?\
+\\(?1:[0-9]+\\(\\.[0-9]+\\)*\\)\\'")
 (defun elpaca-latest-tag (e)
   "Return E's latest merged tag matching recipe tag regexp or `elpaca--tag-regexp'."
   (when-let ((default-directory (elpaca<-repo-dir e))


### PR DESCRIPTION
This PR works in my testing of one package. How I tested it:

- Made org-node-fakeroam depend on org-node "0.10"
- Tag "0.10" is NOT the latest commit in org-node
- My checkouts of both packages are shallow, containing only one commit
- It could still install successfully! It used to complain "version 0 lower than min required".