### PR TITLE
Include "docs", not only "doc" dir

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -137,6 +137,7 @@ Setting it too high causes prints fewer status updates."
 (defvar elpaca-default-files-directive
   '("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
     "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo" "lisp/*.el"
+    "docs/dir" "docs/*.info" "docs/*.texi" "docs/*.texinfo"
     (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "LICENSE"
               "README*" "*-pkg.el"))
   "Default value for the `:files' directive in recipes.


### PR DESCRIPTION
Hi!

This has to do with an issue https://github.com/nobiot/org-transclusion/issues/228 where no Info doc was generated. Now the last issue remaining seems to be that the .texi file is located in "docs" and Elpaca only includes "doc" by default.

I think it makes sense to allow "docs" since it is probably just as entrenched as "doc", on account of [Melpa including both](https://github.com/melpa/melpa).  I don't know about GNU/NonGNU, but I'll guess the same since those repos also successfully build the Info doc.