### PR TITLE
Mostly sync with MELPA :version-regexp

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1174,7 +1174,6 @@ The keyword's value is expected to be one of the following:
                           (elpaca--directory-files-recursively repo (concat "\\`[^.z-a]*" name))))
                     (error "Unable to find main elisp file for %S" package)))))))
 
-;; See `package-build-version-regexp' in https://github.com/melpa/melpa/blob/c84e975e5cd3ff264a134e4608041947ef010f01/package-build/package-build.el#L250
 (defvar elpaca--tag-regexp
   "\\`\\(?:\\|[RVrv]\\|release[/-]v?\\)?\\(?1:[0-9]+\\(\\.[0-9]+\\)*\\)\\'")
 (defun elpaca-latest-tag (e)

--- a/elpaca.el
+++ b/elpaca.el
@@ -1174,7 +1174,9 @@ The keyword's value is expected to be one of the following:
                           (elpaca--directory-files-recursively repo (concat "\\`[^.z-a]*" name))))
                     (error "Unable to find main elisp file for %S" package)))))))
 
-(defvar elpaca--tag-regexp "\\(?:v?\\([[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+\\)\\)")
+;; See `package-build-version-regexp' in https://github.com/melpa/melpa/blob/c84e975e5cd3ff264a134e4608041947ef010f01/package-build/package-build.el#L250
+(defvar elpaca--tag-regexp
+  "\\`\\(?:\\|[RVrv]\\|release[/-]v?\\)?\\(?1:[0-9]+\\(\\.[0-9]+\\)*\\)\\'")
 (defun elpaca-latest-tag (e)
   "Return E's latest merged tag matching recipe tag regexp or `elpaca--tag-regexp'."
   (when-let ((default-directory (elpaca<-repo-dir e))


### PR DESCRIPTION
1. This regexp differs slightly from MELPA's version because it excludes %p, where they would substitute the package name, enabling tags like "elpaca-0.2" if the package is named elpaca.

   If you want, I can sub it in with some `(plist-get recipe ...)`. But maybe this forms a sort of natural boundary, for how smart the version inference should be in the first place. It's convenient to keep it self-contained in the regexp.

2. Let me know if you want me to remove the comment line.