### PR TITLE
Defer elpaca form as a lambda

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -729,9 +729,9 @@ Optional ARGS are passed to `elpaca--signal', which see."
   (when-let* ((forms (nreverse (elpaca-q<-forms q))))
     (with-current-buffer (get-buffer-create " *elpaca--finalize-queue*")
       (setq-local lexical-binding t)
-      (cl-loop for (id . body) in forms
+      (cl-loop for (id . cb) in forms
                do (condition-case-unless-debug err
-                      (eval `(progn ,@body) t)
+                      (funcall cb)
                     ((error) (warn "Config Error %s: %S" id err)))))
     (setf (elpaca-q<-forms q) nil))
   (run-hooks 'elpaca-post-queue-hook)
@@ -1614,14 +1614,14 @@ When quit with \\[keyboard-quit], running sub-processes are not stopped."
     (when (> (elpaca-q<-processed q) 0) (cl-decf (elpaca-q<-processed q)))
     (setf (elpaca-q<-status q) 'incomplete)))
 
-(defun elpaca--expand-declaration (order body)
-  "Expand ORDER declaration, deferring BODY."
+(defun elpaca--expand-declaration (order callback)
+  "Expand ORDER declaration, deferring CALLBACK."
   (unless order (signal 'wrong-type-argument '((or symbolp consp) nil)))
   (when (memq (car-safe order) '(quote \`)) (setq order (eval order t)))
   (let* ((id (elpaca--first order))
          (q (or (and after-init-time (elpaca--q (elpaca-get id))) (car elpaca--queues)))
          (e (elpaca--queue order q)))
-    (when body (setf (alist-get id (elpaca-q<-forms q)) body))
+    (when callback (setf (alist-get id (elpaca-q<-forms q)) callback))
     (when after-init-time
       (elpaca--maybe-log)
       (unless (eq (elpaca--status e) 'failed)
@@ -1639,7 +1639,8 @@ When quit with \\[keyboard-quit], running sub-processes are not stopped."
 Evaluate BODY forms synchronously once ORDER's queue is processed.
 See Info node `(elpaca) Basic Concepts'."
   (declare (indent 1) (debug form))
-  `(elpaca--expand-declaration ',order ',body))
+  (when body (setq body `(lambda () ,@body)))
+  `(elpaca--expand-declaration ',order ,body))
 
 (defvar elpaca--try-package-history nil "History for `elpaca-try'.")
 ;;;###autoload


### PR DESCRIPTION
By deferring the elapca body form as a lambda instead of as an s-expression, the byte-compiler can process it. It won't matter for users who don't byte-compile their init files, but it provides a noticeable speedup for those of us that do.

To actually use this with a byte-compiled init file the user will need to add a few `eval-and-compile` forms to their Elpaca install snippet, but I wanted to keep this change as non-invasive as possible.

Also note: this change won't allow the _native_ compiler to optimize functions defined in deferred forms.