### PR TITLE
elpaca-builds-directory: Use a unique build dir for each Emacs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ Elpaca requires:
 To install Elpaca, add the following elisp to your init.el. It must come before any calls to other Elpaca functions/macros. This will clone Elpaca into your `user-emacs-directory` under the `elpaca` subdirectory. It then builds and activates Elpaca.
 
 ```emacs-lisp
-(defvar elpaca-installer-version 0.10)
+(defvar elpaca-installer-version 0.11)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory
+  (expand-file-name
+   (concat "builds-" (or (bound-and-true-p comp-native-version-dir) emacs-version))
+   elpaca-directory))
 (defvar elpaca-repos-directory (expand-file-name "repos/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore

--- a/elpaca.el
+++ b/elpaca.el
@@ -92,7 +92,10 @@ Results in faster start-up time." :type 'boolean)
 (defvar elpaca-cache-directory (expand-file-name "cache" elpaca-directory)
   "Location of the cache directory.")
 
-(defvar elpaca-builds-directory (expand-file-name "builds" elpaca-directory)
+(defvar elpaca-builds-directory
+  (expand-file-name
+   (concat "builds-" (or (bound-and-true-p comp-native-version-dir) emacs-version))
+   elpaca-directory)
   "Location of the builds directory.")
 
 (defvar elpaca-repos-directory (expand-file-name "repos" elpaca-directory)


### PR DESCRIPTION
Just an idea, consider this a feature request!

I've benefited from this setting, it removes all the friction in testing different versions of Emacs.

While we're looking at README.md, have you considered changing `:depth 1` in `elpaca-order`, to treeless?

I've simply removed `:depth 1` in mine (as `:depth treeless` didn't work for some reason).  Easier to contribute when I can see the commit history, to e.g. look at the style of commit messages and try to follow it :)

By the way, I've finally sent my FSF paperwork, so if you ever want to FSF this codebase, won't need to worry about my PRs.