### PR TITLE
Restrict interactive commands to applicable modes

### DIFF
--- a/elpaca-info.el
+++ b/elpaca-info.el
@@ -40,7 +40,8 @@
 (define-derived-mode elpaca-info-mode special-mode "elpaca-info-mode"
   "Major mode for viewing Elpaca package info.
 
-\\{elpaca-info-mode-map}")
+\\{elpaca-info-mode-map}"
+  :interactive nil)
 
 (defun elpaca-info--menus (id)
   "Return alist of menus filtered for item matching ID."

--- a/elpaca-log.el
+++ b/elpaca-log.el
@@ -149,6 +149,7 @@ It must accept a package ID symbol and REF string as its first two arguments."
 
 (define-minor-mode elpaca-log-update-mode "Auto display update diffs."
   :lighter " elum"
+  :interactive (elapca-log-mode)
   (unless (derived-mode-p 'elpaca-log-mode) (user-error "Not in `elpaca-log-mode' buffer"))
   (if elpaca-log-update-mode
       (progn
@@ -193,7 +194,8 @@ It must accept a package ID symbol and REF string as its first two arguments."
                                        (narrow-to-region (point) (line-end-position))
                                        (condition-case _ (forward-button 1)
                                          (error (user-error "No ref found on current line")))
-                                       (get-text-property (point) 'button-data)))))
+                                       (get-text-property (point) 'button-data))))
+               elpaca-log-mode)
   (funcall elpaca-log-diff-function (car data) (cdr data)))
 
 (defun elpaca-log--updates (entries)
@@ -279,6 +281,7 @@ It must accept a package ID symbol and REF string as its first two arguments."
 
 (define-derived-mode elpaca-log-mode elpaca-ui-mode "elpaca-log-mode"
   "Major mode for displaying Elpaca order log entries."
+  :interactive nil
   (setq tabulated-list-format [("Package" 30 t)
                                ("Status" 20 t)
                                ("Info" 80 t)

--- a/elpaca-manager.el
+++ b/elpaca-manager.el
@@ -59,6 +59,7 @@ If RECACHE is non-nil, recompute `elpaca-manager--entry-cache'."
 
 (define-derived-mode elpaca-manager-mode elpaca-ui-mode "elpaca-manager-mode"
   "Major mode for displaying Elpaca packages."
+  :interactive nil
   (setq tabulated-list-format [("Package" 30 elpaca-ui--sort-package)
                                ("Description" 80 t)
                                ("Date" 15 t)


### PR DESCRIPTION
It's possible to restrict interactive commands to specific modes. This won't make it impossible to run these commands, it'll just hide them in `M-x` completion. This makes it easier to run Elpaca commands with `M-x` without having to sift through a bunch of irrelevant (and often similarly named) commands.

- Restrict minor-modes to applicable major-modes.
- Hide major modes from `M-x` entirely (they should never be enabled manually).
- Restrict all UI commands to `elpaca-ui-mode`, log commands, etc.