### PR TITLE
docs: Update reference to `elpaca-menu-lock-file` in manual

### DIFF
--- a/doc/manual.org
+++ b/doc/manual.org
@@ -610,7 +610,7 @@ A lock file is a collection of recipes for the exact versions of installed packa
 They can be used to build different versions of an Emacs configuration when combined with init file package declarations. 
 
 The =elpaca-write-lock-file= command is used to write a lock file to disk.
-Setting the =elpaca-lock-file= variable to that file's path will cause Elpaca to use those versions of the recipes when installing packages assuming the =elpaca-lock-file-menu= is the first menu in =elpaca-menu-functions=.
+Setting the =elpaca-lock-file= variable to that file's path will cause Elpaca to use those versions of the recipes when installing packages assuming the =elpaca-menu-lock-file= is the first menu in =elpaca-menu-functions=.
 
 
 ** use-package Integration


### PR DESCRIPTION
@progfolio I am pretty sure I need to regenerate the documentation, but I tried exporting [1] but I kept getting `Debugger entered--Lisp error: (wrong-type-argument stringp nil)` after saving my changes to `doc/manual.org`. Hopefully with your guidance I can get the documents generated.

[1] https://github.com/djgoku/elpaca/blob/docs%2Ffix-reference-to-elpaca-menu-lock-file/doc/manual.org?plain=1#L38-L52