### PR TITLE
elpaca-write-lock-file: Improve determinism and diff legibility

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -2029,7 +2029,7 @@ TYPE is either `repo` or `build`, for repo or build directory."
   (interactive "FWrite lock-file to: ")
   (elpaca--write-file path
     (cl-loop
-     with print-circle = t with seen with es
+     with seen with es
      for (id . e) in (or elpacas (elpaca--queued))
      do (when (and (not (member id seen))
                    (run-hook-with-args-until-failure 'elpaca-lock-file-functions e))
@@ -2045,7 +2045,7 @@ TYPE is either `repo` or `build`, for repo or build directory."
                 es)
           (push id seen))
      finally (message "wrote %d elpacas to %s" (length es) path)
-     (pp (nreverse es)))))
+     (pp (cl-sort es #'string< :key (lambda (e) (symbol-name (car e))))))))
 
 (declare-function elpaca-ui-current-package "elpaca-ui")
 ;;;###autoload


### PR DESCRIPTION
This change makes it easier to view diffs to the lockfile in two ways:

- unsetting `print-circle` eliminates noisy changes to circular reference labels (`#n=`, `#n#`) when adding packages. Previously, the combination of `print-circle = t` and `nreverse` would cause lots of changes throughout the lock file as the new package would be first in the list. There's no circular structure in the recipes, so this diff noise seems avoidable.
- sorting by package name makes the lock file deterministic regardless of the order of `elpaca` / `use-package` calls. This prevents noisy diffs from rerderings where the user knows there's no change to behaviour.