### PR TITLE
Add trailing space to search prompt

### DIFF
--- a/elpaca-ui.el
+++ b/elpaca-ui.el
@@ -472,7 +472,7 @@ If QUERY is nil, the contents of the minibuffer are used instead."
               (doc (documentation fn)))
     (concat " " (substring doc 0 (string-search "\n" doc)))))
 
-(defvar elpaca-ui-search-prompt "Search (empty for default query):")
+(defvar elpaca-ui-search-prompt "Search (empty for default query): ")
 
 (defun elpaca-ui--complete-tag ()
   "Return `elpaca-ui-search-tags' as completion candidates."


### PR DESCRIPTION
This simply adds a space after the colon at the end of the search prompt for better readability and for consistency with other prompts ending with a colon throughout Emacs, such as `isearch`'s prompt.
<!-- -->

<!-- Message of single commit: -->

elpaca-ui-search-prompt: add trailing space to string