### PR TITLE
elpaca: use `git checkout -B` for backwards compatibility

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1370,7 +1370,7 @@ This is the branch that would be checked out upon cloning."
             ,@(cond
                (ref    (list "checkout" ref))
                (tag    (list "checkout" (concat "tags/" tag)))
-               (branch (list "switch" "-C" branch ; "--no-guess"?
+               (branch (list "checkout" "-B" branch ; "--no-guess"?
                              (concat (or (elpaca--first remote)
                                          elpaca-default-remote-name)
                                      "/" branch)))))


### PR DESCRIPTION
elpaca: use `git checkout -B` for backwards compatibility

The `git switch -C` introduced in b182f36 is problematic because it's a new CLI subcommand of git 2.23, released in August 2019. Unfortunately, some of the distros and Docker images don't have such up to date git package. This breaks
the backwards compatibility for supposedly no good reason.

Replacing to `checkout` opens up towards much older systems where one would want to use Elpaca on with 1) then Emacs version 2) latest Emacs.

Ref: https://git-scm.com/docs/git-checkout
Ref: https://git-scm.com/docs/git-switch
Ref: https://github.blog/open-source/git/highlights-from-git-2-23/

Sample crash:

```
source: GNU ELPA
url: https://elpa.gnu.org/packages/ascii-art-to-unicode.html
menu item recipe:
( :package "ascii-art-to-unicode"
  :repo ("https://github.com/emacsmirror/gnu_elpa" . "ascii-art-to-unicode")
  :branch "externals/ascii-art-to-unicode"
  :files ("*" (:exclude ".git"))
  :source "GNU ELPA")
full recipe:
( :package "ascii-art-to-unicode"
  ;; Inherited from declaration.
  :depth 1
  ;; Inherited from elpaca-order-functions.
  :inherit t
  :protocol https
  ;; Inherited from elpaca-menu-item.
  :source "GNU ELPA"
  :files ("*" (:exclude ".git"))
  :branch "externals/ascii-art-to-unicode"
  :repo ("https://github.com/emacsmirror/gnu_elpa" . "ascii-art-to-unicode"))
dependencies:
nil
dependents: nil
installed version: 1.13 53b49ff
statuses:
  (failed reclone checking-out-ref cloning queued)
files:
  $REPOS/ascii-art-to-unicode/.gitignore              ! $BUILDS/ascii-art-to-unicode/.gitignore
  $REPOS/ascii-art-to-unicode/HACKING                 ! $BUILDS/ascii-art-to-unicode/HACKING
  $REPOS/ascii-art-to-unicode/NEWS                    ! $BUILDS/ascii-art-to-unicode/NEWS
  $REPOS/ascii-art-to-unicode/THANKS                  ! $BUILDS/ascii-art-to-unicode/THANKS
  $REPOS/ascii-art-to-unicode/ascii-art-to-unicode.el ! $BUILDS/ascii-art-to-unicode/ascii-art-to-unicode.el
log:
  [2025-07-06 13:00:57] Package queued
  [2025-07-06 13:00:57] Continued by: elpaca--process
  [2025-07-06 13:00:57] Cloning
  [2025-07-06 13:00:57] $git clone --depth 1 --single-branch --branch externals/ascii-art-to-unicode https://github.com/emacsmirror/gnu_elpa ~/.emacs.d/elpaca/repos/ascii-art-to-unicode/
  [2025-07-06 13:00:58]   Cloning into '~/.emacs.d/elpaca/repos/ascii-art-to-unicode'...
  [2025-07-06 13:01:00]   remote: Enumerating objects: 7, done.
  [2025-07-06 13:01:00]   remote: Counting objects: 100% (7/7), done.
  [2025-07-06 13:01:00]   remote: Compressing objects: 100% (7/7), done.
  [2025-07-06 13:01:00]   remote: Total 7 (delta 0), reused 4 (delta 0), pack-reused 0 (from 0)
  [2025-07-06 13:01:00]   Unpacking objects: 100% (7/7), done.
  [2025-07-06 13:01:00] Continued by: elpaca--clone-process-sentinel
  [2025-07-06 13:01:00] Continued by: elpaca--configure-remotes
  [2025-07-06 13:01:00] Checking out externals/ascii-art-to-unicode
  [2025-07-06 13:01:00] $git -c advice.detachedHead=false switch -C externals/ascii-art-to-unicode origin/externals/ascii-art-to-unicode
  [2025-07-06 13:01:01]   git: 'switch' is not a git command. See 'git --help'.
  [2025-07-06 13:01:01] Subprocess error (see previous log entries)
```