### PR TITLE
elpaca-test: make `mapconcat` work on Emacs 27.x and 28.x

### DIFF
--- a/elpaca-test.el
+++ b/elpaca-test.el
@@ -106,7 +106,7 @@ If INSTALLERP is non-nil, stop after Elpaca installer."
                  (signal 'end-of-file nil))))
       ((end-of-file) nil)
       ((error) (error (car err) (cdr err))))
-    (mapconcat #'pp-to-string (nreverse body))))
+    (mapconcat #'pp-to-string (nreverse body) "")))
 
 (defun elpaca-test--upstream-init (&optional installer)
   "Return upstream INSTALLER file."


### PR DESCRIPTION
`mapconcat` requires `SEPARATOR` argument which became optional (`""`) in later versions. Running on older versions crashes `elpaca-test.el` with:

```
elpaca-test.el:109:6: Warning: mapconcat called with 2 arguments, but requires 3
```

Ref: https://github.com/emacs-mirror/emacs/blob/647a935/src/fns.c#L2681
Ref: https://github.com/emacs-mirror/emacs/blob/dec9582/src/fns.c#L2858
Ref: https://github.com/emacs-mirror/emacs/blob/75ca15f/src/fns.c#L3049

<!-- -->
