### PR TITLE
elpaca--emacs-releases: add 30.2 release date

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1199,7 +1199,8 @@ The keyword's value is expected to be one of the following:
 
 (defconst elpaca--emacs-releases '(("27.1" . 20200804) ("27.2" . 20210319) ("28.1" . 20220403)
                                    ("28.2" . 20220912) ("29.1" . 20230730) ("29.2" . 20240118)
-                                   ("29.3" . 20240324) ("29.4" . 20240622) ("30.1" . 20250223)))
+                                   ("29.3" . 20240324) ("29.4" . 20240622) ("30.1" . 20250223)
+                                   ("30.2" . 20250814)))
 (defvar elpaca-core-date
   (let ((release (assoc emacs-version elpaca--emacs-releases #'string-prefix-p)))
     (and release (> (length (version-to-list emacs-version)) 2) ;; Development version.


### PR DESCRIPTION
Emacs 30.2 has [been](https://lists.gnu.org/archive/html/info-gnu/2025-08/msg00004.html) [released](https://www.gnu.org/savannah-checkouts/gnu/emacs/emacs.html#Releases).
This PR adds the matching entry to `elpaca--emacs-releases`.