### PR TITLE
elpaca--clone: stop passing --single-branch

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1513,7 +1513,7 @@ This is the branch that would be checked out upon cloning."
                         ((eq depth 'blobless) '("--filter=blob:none"))))))
             ;;@FIX: allow override
             ,@(when-let* ((ref (or (plist-get recipe :branch) (plist-get recipe :tag))))
-                `("--single-branch" "--branch" ,ref))
+                `("--branch" ,ref))
             ,@(unless (or (null remote) (stringp remote)) '("--no-checkout"))
             ,URI ,repodir)))
     (elpaca--make-process e


### PR DESCRIPTION
Just a proposal. Is it a space-saving measure? Because if so then it would be much more effective if this is done for all recipes and not only those where `--branch` or `--tag` is explicitly passed, which must be a minority of a typical user's recipes.

Besides which, I kinda hate single-branch clones because when I [didn't know about them](https://stackoverflow.com/questions/79490805/equivalent-of-unshallow-for-a-treeless-blobless-clone), all attempts to unshallow, refetch or backfill mysteriously did nothing to recreate the origin's branches. So I don't think it should be done on the user's behalf.

EDIT: At least, I think that was because of a single branch clone that one time. Not sure anymore, so maybe I'm wrong to "hate" them. 