### PR TITLE
feat(lock-file): improve experience using lock files

### DIFF
--- a/doc/elpaca.texi
+++ b/doc/elpaca.texi
@@ -908,7 +908,8 @@ A lock file is a collection of recipes for the exact versions of installed packa
 They can be used to build different versions of an Emacs configuration when combined with init file package declarations.
 
 The @samp{elpaca-write-lock-file} command is used to write a lock file to disk.
-Setting the @samp{elpaca-lock-file} variable to that file's path will cause Elpaca to use those versions of the recipes when installing packages assuming the @samp{elpaca-menu-lock-file} is the first menu in @samp{elpaca-menu-functions}.
+The @samp{elpaca-lock-versions} command is a convenience wrapper that writes to the path specified by @samp{elpaca-lock-file}, which defaults to @samp{Elpaca.lock} in @samp{user-emacs-directory}.
+When @samp{elpaca-lock-file} points to a file that exists, it will cause Elpaca to use those versions when installing packages, assuming @samp{elpaca-menu-lock-file} is the first menu in @samp{elpaca-menu-functions}.
 
 @node use-package Integration
 @section use-package Integration

--- a/doc/manual.org
+++ b/doc/manual.org
@@ -507,6 +507,9 @@ The =elpaca-menu-functions= variable contains menu functions for the following p
 Menus are checked in order until one returns the requested menu item or the menu list is exhausted.
 
 **** Updating menus
+:PROPERTIES:
+:CUSTOM_ID: updating-menus
+:END:
 Menus can be updated via the =elpaca-update-menus= command.
 Doing so will fetch the latest recipes from the menu source and overwrite the menu item cache for the updated menus.
 
@@ -615,8 +618,41 @@ It's best to restart Emacs after a successful rebuild if you wish to have the ch
 A lock file is a collection of recipes for the exact versions of installed packages.
 They can be used to build different versions of an Emacs configuration when combined with init file package declarations.
 
-The =elpaca-write-lock-file= command is used to write a lock file to disk.
-Setting the =elpaca-lock-file= variable to that file's path will cause Elpaca to use those versions of the recipes when installing packages assuming the =elpaca-menu-lock-file= is the first menu in =elpaca-menu-functions=.
+**** Writing and Loading Lock Files
+:PROPERTIES:
+:CUSTOM_ID: writing-and-loading-lock-files
+:END:
+
+The =elpaca-write-lock-file= command writes a lock file to a specified path.
+The =elpaca-lock-versions= command is a convenience wrapper that writes to the path specified by =elpaca-lock-file=, which defaults to =Elpaca.lock= in =user-emacs-directory=.
+
+Setting =elpaca-lock-file= to a lock file's path will cause Elpaca to use those versions when installing packages, assuming =elpaca-menu-lock-file= is the first menu in =elpaca-menu-functions=.
+
+The =elpaca-unlock-versions= command deletes the lock file and clears the cache, allowing packages to be installed from their upstream sources again.
+
+**** Force Updating Pinned Packages
+:PROPERTIES:
+:CUSTOM_ID: force-updating-pinned-packages
+:END:
+
+Packages with =:pin t=, =:ref=, or =:tag= in their recipes are normally excluded from update operations.
+The following commands bypass this:
+
+- elpaca-force-update :: Force update a single package, ignoring pin status.
+- elpaca-force-update-all :: Force update all packages, ignoring pin status.
+
+**** Ensuring Pinned Versions
+:PROPERTIES:
+:CUSTOM_ID: ensuring-pinned-versions
+:END:
+
+To verify that pinned packages are at their declared versions:
+
+- elpaca-ensure-pinned :: Check if a package is at its =:ref= or =:tag=; reset if not.
+- elpaca-ensure-pinned-all :: Check all pinned packages and reset any that have drifted.
+
+For packages with only =:pin t= (no specific ref), these commands warn that no version can be ensured.
+For unpinned packages, they are skipped.
 
 
 ** use-package Integration


### PR DESCRIPTION
_Disclaimer: The code is written by Claude Opus 4.5 using Cursor, based on explicit planning from me. Overall I believe the changes look reasonable, and I've manually tested them. That said, I'm not that familiar with Elpaca's codebase, nor do I spend that much time with Elisp, so I'm more than happy to see what more experienced people think._

_I simply wanted some improvements around lock file support myself, and figured I could take a quick stab at it. I won't complain if this is ultimately all thrown away :)_

---

This allows keeping lock files always enabled, while still being able to manually force update individual or all packages at will. I find this useful to maintain exact package across machines until I specifically choose to perform upgrades.

With most systems that allow locking, I simply prefer to always keep them enabled, and use explicit update commands at times of my own choosing.

This is all based on the custom helpers I ended up with in my Emacs config the other day when I did the switch from straight.el to Elpaca: [core/siren-core-packages.el#L68-L108](https://github.com/jimeh/.emacs.d/blob/v0.9.0/core/siren-core-packages.el#L68-L108)

Overview of changes:

- Fix issue where pinned packages would clone repos with a dangling head, preventing `elpaca-update` being able to update the package in the future.
  - Repos always have a local branch tracking the correct remote, pinned repos have that branch force set to the pinned commit SHA.
  - Existing repos on dangling commits will automatically be fixed when `elpaca-update` runs against them.
- Add `elpaca-force-update` and `elpaca-force-update-all` commands, which bypass the pinned ref of packages, force updating them to the latest version. These allow updating packages without having to fully disable the lock file.
- Add `elpaca-lock-versions` and `elpaca-unlock-versions` commands, allowing for easier lock file management. No need to manually set `elpaca-lock-file` and manually write out a lock file. If `elpaca-lock-file` is not set, it will use `Elpaca.lock` within `user-emacs-directory`.
- Add `elpaca-ensure-pinned` and `elpaca-ensure-pinned-all` which resets pinned packages to their pinned ref if needed.

Changes are also sensibly grouped into separate commits for easier slicing and dicing if needed.