### PR TITLE
elpaca: track the remote branch on checkout

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1450,6 +1450,7 @@ This is the branch that would be checked out upon cloning."
                (ref    (list "checkout" ref))
                (tag    (list "checkout" (concat "tags/" tag)))
                (branch (list "checkout" "-B" branch ; "--no-guess"?
+                             "--track"
                              (concat (or (elpaca--first remote)
                                          elpaca-default-remote-name)
                                      "/" branch)))))


### PR DESCRIPTION
When checking branches out on a fork, track the upstream branch. Otherwise:

1. checkout.defaultRemote ensures we succeed to checkout the correct branch.

2. Subsequent attempts to elpaca-fetch will fail because git won't know the correct upstream.

This happens when you specify BOTH an alternative remote AND the non-default branch in that remote. E.g.:

    (pdf-tools
     :files (:defaults ("server" "server/*"))
     :remotes ("rahguzar"
               :fetcher codeberg
               :repo "rahguzar/pdf-tools"
               :branch "child-frame-preview"))