### PR TITLE
Fix mono-repo deadlock when parent is already finished

### DIFF
--- a/elpaca-git.el
+++ b/elpaca-git.el
@@ -370,7 +370,9 @@ COMMAND must satisfy `elpaca--make-process' :command SPEC arg, which see."
   "Populate source files for E :type `git'."
   (if-let* ((mono (elpaca-git--mono-repo (elpaca<-id e) (elpaca<-source-dir e)))
             ((not (memq (elpaca<-id mono) (elpaca<-blocking e)))))
-      (progn
+      (if (eq (elpaca--status mono) 'finished)
+          ;; Source already on disk; skip git steps, proceed to build.
+          (elpaca--continue-build e)
         (push (elpaca<-id mono) (elpaca<-blockers e))
         (push (elpaca<-id e) (elpaca<-blocking mono))
         (setf (elpaca<-statuses e) (list 'blocked 'queued)))


### PR DESCRIPTION
## Summary

- When a mono-repo package (e.g. `elpaca-use-package`) is processed after its parent (e.g. `elpaca`) has already reached `finished` status, the blocking logic added in 1e22eb4 does not account for this: it blocks the child waiting for the parent's status to change, but since the parent already finished, no status change fires `elpaca--check-status` to unblock the child. Result: deadlock.
- This affects both cross-queue scenarios (e.g. `elpaca` in queue 0, `elpaca-use-package` in queue 1) and same-queue scenarios (e.g. multiple packages from the same mono-repo where the first one finishes before the others enter `elpaca-source`).
- Fix: when the mono-repo parent is already finished, skip both blocking and git build steps (the source is already on disk from the parent's operations), proceeding directly to the remaining build steps. This avoids the deadlock and also prevents concurrent git operations when multiple siblings all discover a finished parent simultaneously.

Fixes #512

## Reproduction

1. Delete the elpaca directory to simulate a fresh install
2. Start Emacs — elpaca bootstraps in queue 0, then `elpaca-use-package` is queued in queue 1
3. `elpaca-use-package` hangs forever in `blocked` status, waiting for `elpaca` (which already finished)

The same deadlock can occur with any mono-repo packages (e.g. multiple packages sourced from a single dotfiles repo).