### PR TITLE
Fix debug declarations for defmacro calls

### DIFF
--- a/elpaca-info.el
+++ b/elpaca-info.el
@@ -155,7 +155,7 @@
 
 (defmacro elpaca-info-defsection (name &rest body)
   "Define section function with NAME which evals BODY to return section string."
-  (declare (indent 1))
+  (declare (indent 1 (debug (symbolp body))))
   `(defun ,(intern (format "elpaca-info-section--%s" name)) ()
      ,(format "Insert package's %s." name)
      (let-alist elpaca-info-alist

--- a/elpaca-process.el
+++ b/elpaca-process.el
@@ -83,12 +83,12 @@ Anaphoric bindings provided:
 
 (defmacro elpaca-with-process-call (args &rest body)
   "Evaluate BODY in `elpaca-with-process', applying `elpaca-process-call' to ARGS."
-  (declare (indent 1) (debug 'form))
+  (declare (indent 1) (debug (sexp &rest (&rest form))))
   `(elpaca-with-process (elpaca-process-call ,@(if (listp args) args (list args))) ,@body))
 
 (defmacro elpaca-process-cond (args &rest conditions)
   "Eval CONDITIONS in context of `elpaca-with-process-call' with ARGS."
-  (declare (indent 1) (debug t))
+  (declare (indent 1) (debug (sexp &rest (&rest form))))
   `(elpaca-with-process-call ,args (cond ,@conditions)))
 
 (defun elpaca-process-output (program &rest args)

--- a/elpaca-ui.el
+++ b/elpaca-ui.el
@@ -114,7 +114,7 @@ exclamation point to it. e.g. !#installed."
 
 (defmacro elpaca-defsearch (name query)
   "Return search command with NAME for QUERY."
-  (declare (indent 1) (debug t))
+  (declare (indent 1) (debug (symbolp s stringp)))
   `(defun ,(intern (format "elpaca-ui-search-%s" name)) ()
      ,(format "Search for %S" query)
      (interactive nil elpaca-ui-mode)
@@ -575,7 +575,7 @@ If ADVANCEP is non-nil, move `forward-line'."
 
 (defmacro elpaca-ui-defmark (name test)
   "Define a marking command with NAME and TEST."
-  (declare (indent 1) (debug t))
+  (declare (indent 1) (debug (symbolp form)))
   `(defun ,(intern (format "elpaca-ui-mark-%s"
                            (replace-regexp-in-string "^elpaca-" "" (symbol-name name))))
        () ,(format "Mark package at point for `%s'." name)

--- a/elpaca.el
+++ b/elpaca.el
@@ -986,7 +986,7 @@ ARGS must be a plist including any of the following keywords value pairs:
 :name an expression evaluating to a string, used as the subprocess name.
 :args an expression evaluating to a list of Emacs subprocess command line args.
 :env a `let' VARLIST which is evaluated and injected in the subprocess."
-  (declare (indent 1) (debug t))
+  (declare (indent 1) (debug (form [&optional sexp] body)))
   (let ((esym (make-symbol "e"))
         (formsym (make-symbol "forms"))
         (argsym (make-symbol "args"))
@@ -1482,7 +1482,7 @@ The first to return non-nil suppresses the error."
   "Queue ORDER for asynchronous installation/activation.
 Evaluate BODY forms synchronously once ORDER's queue is processed.
 See Info node `(elpaca) Basic Concepts'."
-  (declare (indent 1) (debug form))
+  (declare (indent 1) (debug (sexp body)))
   `(catch 'elpaca-abort (elpaca--expand-declaration ',order ',body)))
 
 (defvar elpaca--try-package-history nil "History for `elpaca-try'.")
@@ -1786,7 +1786,7 @@ The ARGS plist must contain one of the following values for the :type key:
    ARGS are passed to `elpaca-with-emacs', which see.
 - `system`: each form in BODY is interepreted as (PROGRAM [ARGS...]).
 In addition, the ARGS `:dir` may specify the package `build` or `source` dir."
-  (declare (indent defun))
+  (declare (indent defun) (debug (symbolp sexp body)))
   (if-let* ((type (plist-get args :type))
             ((memq type '(elisp system))))
       `(defun ,name (e)


### PR DESCRIPTION
The previous `debug` declarations on `defmacro` calls were a bit too coarse, and made `edebug` fail with reader errors.
