### PR TITLE
Fix the recipe for org in elpaca-menu-org

### DIFF
--- a/elpaca-menu-org.el
+++ b/elpaca-menu-org.el
@@ -79,13 +79,10 @@
                        :recipe
                        (list
                         :package "org"
-                        :pre-build `(progn (require 'elpaca-menu-org)
-                                           (setq elpaca-menu-org-make-manual ,elpaca-menu-org-make-manual)
-                                           (elpaca-menu-org--build))
                         :host 'github :repo "emacsmirror/org"
                         :autoloads "org-loaddefs.el" :depth 1
-                        :build '((:not (elpaca-build-autoloads))
-                                 (:after elpaca-git--checkout-ref elpaca-menu-org--build))
+                        :build '((:not elpaca-build-autoloads)
+                                 (:before elpaca-build-link elpaca-menu-org--build))
                         :files '(:defaults ("etc/styles/" "etc/styles/*" "doc/*.texi")))))
            (cons 'org-contrib
                  (list :source "Org"


### PR DESCRIPTION
First, of all, thank you for `elpaca`! I've been using it for quite a while now, and it's been very pleasant 🙂 

After I upgraded to the latest version of elpaca, I noticed that `org` was failing to find `org-version`. It looks like the culprit was an outdated build recipe. I'm not sure that `:before elpaca-build-link` is the best place to run the build step, but it seems reasonable? The previous choice of `elpaca-git--checkout-ref` did not work, as it was not listed in the steps. Also, the `(:not (elpaca-build-autoloads))` substitution was not firing due to the extra parens: I've fixed this as well. 

As an aside, it might be nice to get some warnings if `elpaca-substitute-build-steps` does not perform a substitution; I had to step through with `edebug` to see what was going on.