### PR TITLE
Fix typo in elpaca-source-dir orphan specializer

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -1571,7 +1571,7 @@ FILTER must be a unary function which accepts and returns a queue list."
     (or (when-let* ((src (elpaca<-source-dir e))) (file-exists-p src))
         (when-let* ((build (elpaca<-build-dir e))) (file-exists-p build)))))
 
-(cl-defmethod elpaca-source-dir ((e (elpaca oprhan)))
+(cl-defmethod elpaca-source-dir ((e (elpaca orphan)))
   "Return source dir for :type `orphan` E."
   (plist-get (elpaca<-recipe e) :main))
 


### PR DESCRIPTION
The `cl-defmethod` specializer for `elpaca-source-dir` is misspelled as
`oprhan` instead of `orphan` (introduced in ec427c3), making the method
dead code.

The generic fallback currently produces the same result by coincidence,
so orphan deletion still works. However, the intended orphan-specific
method never dispatches, which would cause issues if the orphan codepath
is extended (e.g., orphans in non-standard locations).

Change: `(elpaca oprhan)` → `(elpaca orphan)` in the specializer.