### PR TITLE
Fix typo in elpaca-build-docs-process-sentinel

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -963,7 +963,7 @@ FILES and NOCONS are used recursively."
          (finished (equal event "finished\n")))
     (unless finished
       (setf (elpaca<-build-steps e)
-            (cl-remove 'elpaca--isntall-info (elpaca<-build-steps e))))
+            (cl-remove 'elpaca--install-info (elpaca<-build-steps e))))
     (elpaca--propertize-subprocess process)
     (elpaca--continue-build
      e (if finished "Info compiled" (concat "Compilation failure: " (string-trim event))))))


### PR DESCRIPTION
The cl-remove call referenced the misspelled symbol elpaca--isntall-info instead of elpaca--install-info, making it a no-op when makeinfo fails. This caused elpaca--install-info to run even after compilation failure.