### PR TITLE
Further improve edebug declarations

### DIFF
--- a/elpaca-info.el
+++ b/elpaca-info.el
@@ -155,7 +155,7 @@
 
 (defmacro elpaca-info-defsection (name &rest body)
   "Define section function with NAME which evals BODY to return section string."
-  (declare (indent 1) (debug (symbolp body)))
+  (declare (indent 1) (debug (symbolp def-body)))
   `(defun ,(intern (format "elpaca-info-section--%s" name)) ()
      ,(format "Insert package's %s." name)
      (let-alist elpaca-info-alist

--- a/elpaca-process.el
+++ b/elpaca-process.el
@@ -69,7 +69,7 @@ Anaphoric bindings provided:
   failure: t if process did not invoke or exited with a nonzero code
   stdout: output of stdout
   stderr: output of stderr"
-  (declare (indent 1) (debug t))
+  (declare (indent 1) (debug (form body)))
   `(let* ((result ,result)
           (exit (car result))
           (invoked (numberp exit))
@@ -88,7 +88,7 @@ Anaphoric bindings provided:
 
 (defmacro elpaca-process-cond (args &rest conditions)
   "Eval CONDITIONS in context of `elpaca-with-process-call' with ARGS."
-  (declare (indent 1) (debug (sexp body)))
+  (declare (indent 1) (debug (sexp &rest (form body))))
   `(elpaca-with-process-call ,args (cond ,@conditions)))
 
 (defun elpaca-process-output (program &rest args)

--- a/elpaca-process.el
+++ b/elpaca-process.el
@@ -83,12 +83,12 @@ Anaphoric bindings provided:
 
 (defmacro elpaca-with-process-call (args &rest body)
   "Evaluate BODY in `elpaca-with-process', applying `elpaca-process-call' to ARGS."
-  (declare (indent 1) (debug (sexp &rest (&rest form))))
+  (declare (indent 1) (debug (sexp body)))
   `(elpaca-with-process (elpaca-process-call ,@(if (listp args) args (list args))) ,@body))
 
 (defmacro elpaca-process-cond (args &rest conditions)
   "Eval CONDITIONS in context of `elpaca-with-process-call' with ARGS."
-  (declare (indent 1) (debug (sexp &rest (&rest form))))
+  (declare (indent 1) (debug (sexp body)))
   `(elpaca-with-process-call ,args (cond ,@conditions)))
 
 (defun elpaca-process-output (program &rest args)

--- a/elpaca-ui.el
+++ b/elpaca-ui.el
@@ -114,7 +114,7 @@ exclamation point to it. e.g. !#installed."
 
 (defmacro elpaca-defsearch (name query)
   "Return search command with NAME for QUERY."
-  (declare (indent 1) (debug (symbolp s stringp)))
+  (declare (indent 1) (debug (symbolp stringp)))
   `(defun ,(intern (format "elpaca-ui-search-%s" name)) ()
      ,(format "Search for %S" query)
      (interactive nil elpaca-ui-mode)

--- a/elpaca.el
+++ b/elpaca.el
@@ -1790,7 +1790,7 @@ Any function returning nil will prevent the E from being written to the file."
 (defmacro elpaca-with-dir (e type &rest body)
   "Evaluate BODY with E's `default-directory' bound.
 TYPE is either `source` or `build`, for source or build directory."
-  (declare (indent 2) (debug (symbolp symbolp &rest form)))
+  (declare (indent 2) (debug (symbolp symbolp body)))
   `(let ((default-directory (,(intern (format "elpaca<-%s-dir" (symbol-name type))) ,e)))
      ,@body))
 
@@ -1802,7 +1802,7 @@ The ARGS plist must contain one of the following values for the :type key:
    ARGS are passed to `elpaca-with-emacs', which see.
 - `system`: each form in BODY is interepreted as (PROGRAM [ARGS...]).
 In addition, the ARGS `:dir` may specify the package `build` or `source` dir."
-  (declare (indent defun) (debug (symbolp sexp body)))
+  (declare (indent defun) (debug (symbolp sexp def-body)))
   (if-let* ((type (plist-get args :type))
             ((memq type '(elisp system))))
       `(defun ,name (e)


### PR DESCRIPTION
I started working on this because I noticed an extraneous `s` symbol in the debug declaration for `elpaca-defsearch`. Then I got a bit carried away and decided to turn this into a learning experience.