### PR TITLE
Rework log throttle logic

### DIFF
--- a/elpaca-log.el
+++ b/elpaca-log.el
@@ -239,16 +239,9 @@ It must accept a package ID symbol and REF string as its first two arguments."
   (< (string-to-number (aref (cadr a) 3))
      (string-to-number (aref (cadr b) 3))))
 
-(defvar elpaca-log--update-timer nil "Debounce timer for log buffer updates.")
-
 (defun elpaca-log--on-status-change (_e)
   "Refresh log buffer when any package status changes."
-  (when (buffer-live-p (get-buffer elpaca-log-buffer))
-    (when elpaca-log--update-timer (cancel-timer elpaca-log--update-timer))
-    (if elpaca--waiting
-        (elpaca--update-log-buffer)
-      (setq elpaca-log--update-timer
-            (run-at-time elpaca-log-interval nil #'elpaca--update-log-buffer)))))
+  (elpaca--update-log-buffer))
 
 (defun elpaca-log--subscribe ()
   "Set up log buffer subscriptions."

--- a/elpaca.el
+++ b/elpaca.el
@@ -750,7 +750,9 @@ without throttling."
     (when elpaca--update-log-timer
       (cancel-timer elpaca--update-log-timer)
       (setq elpaca--update-log-timer nil))
-    (when-let* ((log (bound-and-true-p elpaca-log-buffer)))
+    (when-let* ((log (bound-and-true-p elpaca-log-buffer))
+                (log (get-buffer log))
+                ((buffer-live-p log)))
       (with-current-buffer log
         (remove-hook 'window-buffer-change-functions 'elpaca--update-log-buffer t)
         (if (get-buffer-window log t)  ;; log buffer visible

--- a/elpaca.el
+++ b/elpaca.el
@@ -739,13 +739,25 @@ The first function, if any, which returns non-nil is used." :type 'hook)
     e))
 
 (declare-function elpaca-ui--update-search-query "elpaca-ui")
-(defun elpaca--update-log-buffer ()
-  "Update views in `elpaca-log-buffer'."
-  (when-let* ((log (bound-and-true-p elpaca-log-buffer))
-              ((get-buffer-window log t))) ;; log buffer visible
-    (with-current-buffer log (elpaca-ui--update-search-query log))))
-
+(defvar elpaca--update-log-timer nil "Debounce timer for log buffer updates.")
 (defvar elpaca--waiting nil "Non-nil when `elpaca-wait' is polling.")
+(defun elpaca--update-log-buffer (&optional immediate)
+  "Update views in `elpaca-log-buffer'.
+When IMMEDIATE is non-nil, update `elpaca-log-buffer' immediately
+without throttling."
+  (cond
+   ((or immediate elpaca--waiting)
+    (when elpaca--update-log-timer
+      (cancel-timer elpaca--update-log-timer)
+      (setq elpaca--update-log-timer nil))
+    (when-let* ((log (bound-and-true-p elpaca-log-buffer))
+                ((get-buffer-window log t))) ;; log buffer visible
+      (with-current-buffer log (elpaca-ui--update-search-query log))))
+   ((not elpaca--update-log-timer)
+    (setq elpaca--update-log-timer (run-at-time elpaca-log-interval nil
+                                         #'elpaca--update-log-buffer
+                                         'immediate)))))
+
 (defun elpaca--count-statuses ()
   "Return alist of status symbol to count across all queues."
   (cl-loop with counts for q in elpaca--queues
@@ -2015,8 +2027,6 @@ OUTPUT may be any of the following:
 
 ;;; Status subscribers
 
-(defvar elpaca--log-debounce-timer nil "Timer to debounce log buffer updates.")
-
 (defun elpaca--maybe-log-on-failure (e)
   "Open log if E failed during init."
   (ignore e)
@@ -2076,11 +2086,7 @@ opened by a package finishing or blocking on deps is immediately filled."
 
 (defun elpaca--log-update-on-info (_e)
   "Debounce log buffer update after E emits an info event."
-  (when elpaca--log-debounce-timer (cancel-timer elpaca--log-debounce-timer))
-  (if elpaca--waiting
-      (elpaca--update-log-buffer)
-    (setq elpaca--log-debounce-timer
-          (run-at-time elpaca-log-interval nil #'elpaca--update-log-buffer))))
+  (elpaca--update-log-buffer))
 
 (defun elpaca--subscribe ()
   "Wire up core status subscribers."

--- a/elpaca.el
+++ b/elpaca.el
@@ -750,9 +750,13 @@ without throttling."
     (when elpaca--update-log-timer
       (cancel-timer elpaca--update-log-timer)
       (setq elpaca--update-log-timer nil))
-    (when-let* ((log (bound-and-true-p elpaca-log-buffer))
-                ((get-buffer-window log t))) ;; log buffer visible
-      (with-current-buffer log (elpaca-ui--update-search-query log))))
+    (when-let* ((log (bound-and-true-p elpaca-log-buffer)))
+      (with-current-buffer log
+        (remove-hook 'window-buffer-change-functions 'elpaca--update-log-buffer t)
+        (if (get-buffer-window log t)  ;; log buffer visible
+            (elpaca-ui--update-search-query log)
+          (add-hook 'window-buffer-change-functions
+                    'elpaca--update-log-buffer nil 'local)))))
    ((not elpaca--update-log-timer)
     (setq elpaca--update-log-timer (run-at-time elpaca-log-interval nil
                                          #'elpaca--update-log-buffer


### PR DESCRIPTION
There are three patches in this PR:

**The first patch** move all the log rate-limiting logic into `elpaca--update-log-buffer` to ensure it gets applied consistently everywhere and changes it to be a throttle instead of a debounce. That is, instead of canceling/extending the timer each time (possibly indefinitely), it uses the timer to rate-limit updates.

**The second patch** updates the log buffer when displayed, if prior updates were skipped due to the buffer being invisible.

**The third patch** checks that the log buffer if live before attempting to update it.