### PR TITLE
Cancel the "blocked process" timer when the process exits

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -952,6 +952,8 @@ FILES and NOCONS are used recursively."
 
 (defun elpaca--process-sentinel (&optional info status process event)
   "Update E's INFO and STATUS when PROCESS EVENT is finished."
+  (when-let* ((timer (process-get process :timer)))
+    (cancel-timer timer))
   (if-let* ((e (process-get process :elpaca))
             ((and (equal event "finished\n") (not (eq (elpaca--status e) 'failed)))))
       (progn (elpaca--propertize-subprocess process)


### PR DESCRIPTION
This avoids a CPU spike one minute after calling `elapca-fetch-all`.

Fix proposed by @bramadams.

fixes #534