### PR TITLE
Include tags in `elpaca--log-updates' output

### DIFF
--- a/elpaca-git.el
+++ b/elpaca-git.el
@@ -33,6 +33,10 @@
   "List of steps which are run when installing/building a package."
   :type '(repeat function))
 
+(defcustom elpaca-git-log-updates-include-tags nil
+  "When non-nil, include Git tag decorations in update log entries."
+  :type 'boolean)
+
 (defsubst elpaca-git--repo-name (string)
   "Return repo name portion of STRING."
   (setq string (directory-file-name string)) ;; remove external :repo trailing slash
@@ -399,8 +403,11 @@ COMMAND must satisfy `elpaca--make-process' :command SPEC arg, which see."
     (elpaca--make-process e
       :name "log-updates"
       ;; Pager breaks pipe process.
-      :command (list "git" "--no-pager" "log" "--reverse" (concat "--since=" date)
-                     "--pretty=%h %s (%ch)" "..@{u}")
+      :command (append (list "git" "--no-pager" "log" "--reverse" (concat "--since=" date)
+                             (if elpaca-git-log-updates-include-tags "--pretty=%h%d %s (%ch)"
+                               "--pretty=%h %s (%ch)"))
+                       (when elpaca-git-log-updates-include-tags '("--decorate-refs=tags"))
+                       (list "..@{u}"))
       :sentinel (lambda (process event) (elpaca--process-sentinel nil process event)))))
 
 (cl-defmethod elpaca--url ((e (elpaca git)))


### PR DESCRIPTION
Makes it easier to determine from the elpaca logs if a new stable version (tag) of a git repository is available. Configurable via a `defcustom`.

Excluding other types of refs in order not to overload the output.