### PR TITLE
Allow selecting specific commit to merge instead of all commits

### DIFF
--- a/elpaca-log.el
+++ b/elpaca-log.el
@@ -264,6 +264,7 @@ It must accept a package ID symbol and REF string as its first two arguments."
     (set-keymap-parent m elpaca-ui-mode-map)
     (define-key m (kbd "gd") 'elpaca-log-view-diff)
     (define-key m (kbd "gu") 'elpaca-log-updates)
+    (define-key m (kbd "t") 'elpaca-ui-mark-merge-to)
     m))
 
 (define-derived-mode elpaca-log-mode elpaca-ui-mode "elpaca-log-mode"

--- a/elpaca-ui.el
+++ b/elpaca-ui.el
@@ -35,7 +35,8 @@
     (elpaca-rebuild :prefix "♻️️" :face elpaca-ui-marked-rebuild)
     (elpaca-fetch   :prefix "‍🐕‍🦺" :face elpaca-ui-marked-fetch)
     (elpaca-merge   :prefix "🤝" :face elpaca-ui-marked-merge :args (id prefix-arg))
-    (elpaca-pull    :prefix "⬆️" :face elpaca-ui-marked-pull :args (id prefix-arg)))
+    (elpaca-pull    :prefix "⬆️" :face elpaca-ui-marked-pull :args (id prefix-arg))
+    (elpaca-merge-to :prefix "📌" :face elpaca-ui-marked-merge :args (id prefix-arg)))
 
   "List of marks which can be applied to packages `elpaca-ui-mode' buffers.
 Each element is of the form (COMMAND :KEY VAL...).
@@ -265,7 +266,10 @@ If PREFIX is non-nil it is displayed before the rest of the header-line."
              (progn (setq noconflict nil) 'elpaca-ui-conflicting))
            '(:weight bold))))
     (if-let* ((noconflict)
-              (marked (cl-find id elpaca-ui--marked-packages :key #'car)))
+              (marked (cl-find id elpaca-ui--marked-packages :key #'car))
+              ((or (not (eq (cadr marked) 'elpaca-merge-to))
+                   (when-let* ((commit (plist-get (nthcdr 2 marked) :prefix-arg)))
+                     (string-prefix-p commit (substring-no-properties (aref entry 2)))))))
         (if (memq id elpaca-ui--marked)
             (add-text-properties beg (+ beg namelen)
                                  (list 'display (propertize name 'face 'elpaca-ui-conflicting)
@@ -593,6 +597,19 @@ If ADVANCEP is non-nil, move `forward-line'."
 (elpaca-ui-defmark elpaca-fetch #'elpaca-ui--ensure-installed)
 (elpaca-ui-defmark elpaca-merge #'elpaca-ui--ensure-installed)
 (elpaca-ui-defmark elpaca-pull  #'elpaca-ui--ensure-installed)
+
+(defun elpaca-ui-mark-merge-to ()
+  "Mark package at point for `elpaca-merge-to' using commit hash from current log entry."
+  (interactive nil elpaca-ui-mode)
+  (let* ((entry (tabulated-list-get-entry))
+         (info (and entry (substring-no-properties (aref entry 2))))
+         (commit (and info
+                      (string-match "\\`[[:space:]]*\\([0-9a-f]\\{7,40\\}\\)\\_>" info)
+                      (match-string 1 info))))
+    (unless commit
+      (user-error "Not an update-log entry"))
+    (let ((current-prefix-arg commit))
+      (elpaca-ui-mark :region 'elpaca-merge-to #'elpaca-ui--ensure-installed 'advance))))
 
 (elpaca-ui-defmark elpaca-try
   (lambda (p) (when (elpaca-installed-p p) (user-error "Package %S already installed" p))))

--- a/elpaca.el
+++ b/elpaca.el
@@ -643,7 +643,7 @@ TYPE is one of the following keywords:
 (defcustom elpaca-log-command-queries
   '(((elpaca-fetch elpaca-fetch-all elpaca-log-updates) . "#latest #update-log")
     ((elpaca-try elpaca-rebuild) . "#latest #linked-errors")
-    (( elpaca-merge elpaca-merge-all elpaca-pull elpaca-pull-all
+    (( elpaca-merge elpaca-merge-all elpaca-merge-to elpaca-pull elpaca-pull-all
        elpaca-update elpaca-update-all)
      . "#latest #unique")
     ((eval-buffer eval-region eval-defun eval-last-sexp org-ctrl-c-ctrl-c) . silent)
@@ -1802,6 +1802,23 @@ If INTERACTIVE is non-nil immediately process, otherwise queue."
   "Install E's fetched updates."
   (error "No merge method for :type %S" (plist-get (elpaca<-recipe e) :type)))
 
+(defvar elpaca--merge-to-targets nil "Alist of package ID to target commit hash.")
+
+(defun elpaca--merge-to (e)
+  "Merge E's repo to a specific commit."
+  (let* ((id (elpaca<-id e))
+         (commit (or (alist-get id elpaca--merge-to-targets)
+                     (error "No merge-to target for %S" id)))
+         (default-directory (elpaca<-source-dir e))
+         (rev (elpaca-process-output "git" "rev-parse" "HEAD")))
+    (process-put (elpaca--make-process e
+                   :name "merge-to"
+                   :command (list "git" "merge" "--ff-only" commit)
+                   :sentinel #'elpaca-git--merge-process-sentinel)
+                 :elpaca-git-rev rev)
+    (setf (alist-get id elpaca--merge-to-targets nil 'remove) nil)
+    (elpaca-note e (format "Merging to %s" commit))))
+
 ;;;###autoload
 (defun elpaca-merge (id &optional fetch interactive)
   "Install package updates associated with ID.
@@ -1812,6 +1829,22 @@ If INTERACTIVE is non-nil, the queued order is processed immediately."
     (elpaca--unprocess e)
     (setf (elpaca<-build-steps e)
           (elpaca-build-steps e (if fetch :pull :merge)))
+    (elpaca--set-status e 'queued)
+    (when interactive
+      (elpaca--maybe-log)
+      (elpaca--process e))))
+
+;;;###autoload
+(defun elpaca-merge-to (id commit &optional interactive)
+  "Merge package associated with ID to specific COMMIT and rebuild.
+If INTERACTIVE is non-nil, the queued order is processed immediately."
+  (interactive (list (elpaca--read-queued "Merge-to package: ") nil t))
+  (let* ((e (or (elpaca-get id) (user-error "Package %S is not queued" id))))
+    (when commit (setf (alist-get id elpaca--merge-to-targets) commit))
+    (elpaca--unprocess e)
+    (setf (elpaca<-build-steps e)
+          (if (elpaca-pinned-p e) (list #'elpaca--announce-pin)
+            (cons #'elpaca--merge-to (cdr (elpaca-build-steps e :merge)))))
     (elpaca--set-status e 'queued)
     (when interactive
       (elpaca--maybe-log)


### PR DESCRIPTION
Added the `elpaca-merge-to` mark and supporting code such that `elpaca-fetch` and `elpaca-fetch-all` both allow to select the specific commit to merge instead of merging all fetched commits.

Uses "t" key to select the specific commit of a git source. Selecting another commit of the same source replaces the previously chosen commit.