### PR TITLE
fix: after-init timing and unblock resume

### DIFF
--- a/elpaca.el
+++ b/elpaca.el
@@ -375,7 +375,9 @@ waiting Es are failed.  Otherwise all waiting Es are unblocked."
           (elpaca-note e (format "Condition (%S . %S) satisfied" type value)
                        :face 'elpaca-finished)
           (unless (elpaca<-conditions e)
-            (elpaca--set-status e 'active)))))))
+            (if (elpaca<-current-step e)
+                (elpaca--set-status e 'active)
+              (elpaca-continue e))))))))
 
 (defun elpaca-merge-plists (&rest plists)
   "Return plist with set of unique keys from PLISTS.
@@ -888,6 +890,8 @@ Each function receives the queue struct as its sole argument." :type 'hook)
     (run-hooks 'elpaca-post-queue-hook))
   (let ((next (nth (1+ (elpaca-q<-id q)) (reverse elpaca--queues))))
     (unless (or elpaca-after-init-time
+                elpaca--waiting
+                (not after-init-time)
                 (not (eq (elpaca-q<-type q) 'init))
                 (and next (eq (elpaca-q<-type next) 'init)))
       (elpaca-split-queue)
@@ -1650,7 +1654,7 @@ FILTER must be a unary function which accepts and returns a queue list."
                                    when (elpaca-q<-elpacas q) return q)))
         (progn (elpaca--maybe-log)
                (elpaca--process-queue incomplete))
-      (unless elpaca-after-init-time
+      (unless (or elpaca-after-init-time elpaca--waiting (not after-init-time))
         (setq elpaca-after-init-time (current-time))
         (run-hooks 'elpaca-after-init-hook))
       (run-hooks 'elpaca--post-queues-hook))))

--- a/test/elpaca-tests.el
+++ b/test/elpaca-tests.el
@@ -91,6 +91,10 @@
   "Turn off ORDER inheritance."
   '(:inherit nil))
 
+(defun elpaca-tests--make-init-queue (&optional elpacas)
+  "Return an init queue containing ELPACAS."
+  (elpaca-q<-create :type 'init :id 0 :elpacas elpacas))
+
 (ert-deftest elpaca-recipe ()
   "Compute recipe from ORDER."
   (let ((elpaca-recipe-functions nil))
@@ -120,6 +124,56 @@
                   :inherit t
                   :pre-build ("./pre-build"))
                (elpaca-recipe '(elpaca :inherit t)))))))
+
+(ert-deftest elpaca-resolve-resumes-pre-step-waiters ()
+  "Resolving the last condition should continue pre-step waiters."
+  (let* ((key '(finished . elpaca))
+         (elpaca--conditions (make-hash-table :test #'equal))
+         (continued nil)
+         (status-changes nil)
+         (e (elpaca<--create :id 'elpaca :conditions (list key))))
+    (puthash key (list e) elpaca--conditions)
+    (cl-letf (((symbol-function 'elpaca-continue)
+               (lambda (waiter) (setq continued waiter)))
+              ((symbol-function 'elpaca--set-status)
+               (lambda (waiter status) (push (cons waiter status) status-changes)))
+              ((symbol-function 'elpaca-note) #'ignore))
+      (elpaca-resolve 'finished 'elpaca))
+    (should (eq continued e))
+    (should-not status-changes)
+    (should-not (elpaca<-conditions e))
+    (should-not (gethash key elpaca--conditions))))
+
+(ert-deftest elpaca-finalize-queue-defers-after-init-until-emacs-finishes-init ()
+  "Do not run `elpaca-after-init-hook' before Emacs sets `after-init-time'."
+  (let* ((after-init-time nil)
+         (elpaca-after-init-time nil)
+         (elpaca--waiting nil)
+         (elpaca-post-queue-hook nil)
+         (elpaca--post-queues-hook nil)
+         (elpaca-queue-start-functions nil)
+         (elpaca-queue-finish-functions nil)
+         (hook-ran nil)
+         (elpaca-after-init-hook (list (lambda () (setq hook-ran t))))
+         (q (elpaca-tests--make-init-queue)))
+    (let ((elpaca--queues (list q)))
+      (elpaca--finalize-queue q))
+    (should-not hook-ran)
+    (should-not elpaca-after-init-time)))
+
+(ert-deftest elpaca-process-queues-defers-after-init-until-emacs-finishes-init ()
+  "Do not run `elpaca-after-init-hook' from the fallback path before init ends."
+  (let* ((after-init-time nil)
+         (elpaca-after-init-time nil)
+         (elpaca--waiting nil)
+         (elpaca--debug-init nil)
+         (elpaca--post-queues-hook nil)
+         (hook-ran nil)
+         (elpaca-after-init-hook (list (lambda () (setq hook-ran t))))
+         (elpaca--queues (list (elpaca-tests--make-init-queue))))
+    (elpaca-process-queues)
+    (should-not hook-ran)
+    (should-not elpaca-after-init-time)))
 
 (provide 'elpaca-tests)
 ;; Local Variables:

--- a/test/elpaca-tests.el
+++ b/test/elpaca-tests.el
@@ -41,17 +41,18 @@
                           keys))
               (cdr plists))))
 
-(defun elpaca-tests-menu (request)
-  "A test menu. REQUEST RECIPE."
+(defun elpaca-tests-menu (request &optional item)
+  "A test menu. REQUEST and optional ITEM."
   (let ((recipes '((:package "a" :host gitlab :repo "a/a")
                    ( :package "elpaca" :host github :repo "progfolio/elpaca"
                      :pre-build ("./pre-build")))))
     (pcase request
-      ('index  (mapcar (lambda (recipe) (cons
-                                         (intern-soft (plist-get recipe :package))
-                                         (list :source "test-menu"
-                                               :recipe recipe)))
-                       recipes))
+      ('index  (let ((items (mapcar (lambda (recipe) (cons
+                                                     (intern-soft (plist-get recipe :package))
+                                                     (list :source "test-menu"
+                                                           :recipe recipe)))
+                                   recipes)))
+                 (if item (alist-get item items) items)))
       (_ (user-error "Unimplmented request method: %S" request)))))
 
 (ert-deftest elpaca-merge-plists ()
@@ -72,15 +73,15 @@
 (ert-deftest elpaca-menu-item ()
   "Return menu item from MENUS."
   (should
-   (let ((elpaca-menu-functions '(elpaca-tests-menu))
+     (let ((elpaca-menu-functions '(elpaca-tests-menu))
          elpaca--menu-cache)
-     (elpaca-tests--plist-equal-p
-      '(elpaca :source "test-menu"
-               :recipe (:package "elpaca"
-                                 :host github
-                                 :repo "progfolio/elpaca"
-                                 :pre-build
-                                 ("./pre-build")))
+       (elpaca-tests--plist-equal-p
+      '(:source "test-menu"
+                :recipe (:package "elpaca"
+                                  :host github
+                                  :repo "progfolio/elpaca"
+                                  :pre-build
+                                  ("./pre-build")))
       (elpaca-menu-item 'elpaca))))
   (should-not (let ((elpaca-menu-functions '(ignore))
                     elpaca--menu-cache)
@@ -95,13 +96,13 @@
   (let ((elpaca-recipe-functions nil))
     ;; no inheritance, full spec
     (should (elpaca-tests--plist-equal-p
-             (elpaca-recipe '(elpaca :host github :repo "progfolio/elpaca" :inherit nil))
-             '(:package "elpaca" :host github :repo "progfolio/elpaca" :inherit nil)))
+             '(:package "elpaca" :host github :repo "progfolio/elpaca" :inherit nil)
+             (elpaca-recipe '(elpaca :host github :repo "progfolio/elpaca" :inherit nil))))
     ;; basic default inheritance
     (let ((elpaca-order-functions '(elpaca-tests--no-inheritance)))
       (should (elpaca-tests--plist-equal-p
-               (elpaca-recipe '(elpaca :host github :repo "progfolio/elpaca"))
-               '(:package "elpaca" :host github :repo "progfolio/elpaca" :inherit nil))))
+               '(:package "elpaca" :host github :repo "progfolio/elpaca" :inherit nil)
+               (elpaca-recipe '(elpaca :host github :repo "progfolio/elpaca")))))
     ;; basic menu lookup
     (let ((elpaca-order-functions '(elpaca-tests--no-inheritance))
           (elpaca-menu-functions '(elpaca-tests-menu))


### PR DESCRIPTION
This fixes a startup race introduced by the event/condition refactor where `elpaca-after-init-hook` could fire before Emacs had actually finished loading the user's init file.

It also fixes a related unblock regression where packages waiting on a condition before their first build step could become `active` without ever resuming.

Both reported in https://github.com/progfolio/elpaca/issues/545.

Tested with my personal config with `emacs --init-directory /tmp/emacs-test` (a fresh empty folder) and it bootstrapped successfully as it used to.

## What changed
- Prevent `elpaca--finalize-queue` from setting `elpaca-after-init-time` or running `elpaca-after-init-hook` while `elpaca-wait` is active and before Emacs `after-init-time` is **non-nil**
- Prevent the fallback path in `elpaca-process-queues` from running `elpaca-after-init-hook` under the same conditions
- When `elpaca-resolve` clears the last blocking condition for a package, resume with `elpaca-continue` if the package has not started its first step and keep the existing `active` transition for packages resuming mid-build

## Why

- bootstrap sequences using `elpaca-use-package` with `:wait t` could mark `elpaca-after-init-time` too early
- later `add-hook 'elpaca-after-init-hook ...` forms in the user's init file would miss the event entirely
- some condition-unblocked packages could remain stuck after logging that their condition was satisfied

## Tests

Added regression coverage for:

- deferring `elpaca-after-init-hook` until Emacs has actually finished init
- resuming pre-step waiters when their final condition is resolved

Also updated two existing tests to match current `elpaca-menu-item` and `elpaca-recipe` behaviour.

## Verification

```bash
emacs --batch -Q -L . -L test -l ert -l elpaca-tests -f ert-run-tests-batch-and-exit`
```