### PR TITLE
Make the build directory Emacs-version specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ To install Elpaca, add the following elisp to your init.el. It must come before 
 ```emacs-lisp
 (defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory (expand-file-name (format "builds/%s/" emacs-version)
+                                                  elpaca-directory))
 (defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore

--- a/doc/common.org
+++ b/doc/common.org
@@ -61,7 +61,8 @@ It then builds and activates Elpaca.
 #+begin_src emacs-lisp :lexical t :eval never-export
 (defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory (expand-file-name (format "builds/%s/" emacs-version)
+                                                  elpaca-directory))
 (defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore

--- a/doc/elpaca.texi
+++ b/doc/elpaca.texi
@@ -129,7 +129,8 @@ It then builds and activates Elpaca.
 @lisp
 (defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory (expand-file-name (format "builds/%s/" emacs-version)
+                                                  elpaca-directory))
 (defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore

--- a/doc/init.el
+++ b/doc/init.el
@@ -1,7 +1,8 @@
 ;; Example Elpaca configuration -*- lexical-binding: t; -*-
 (defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory (expand-file-name (format "builds/%s/" emacs-version)
+                                                  elpaca-directory))
 (defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore

--- a/doc/installer.el
+++ b/doc/installer.el
@@ -2,7 +2,8 @@
 ;; Copy below this line into your init.el
 (defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory (expand-file-name (format "builds/%s/" emacs-version)
+                                                  elpaca-directory))
 (defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -73,7 +73,8 @@ To install Elpaca, add the following elisp to your init.el. It must come before 
 ```emacs-lisp
 (defvar elpaca-installer-version 0.12)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
-(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-builds-directory (expand-file-name (format "builds/%s/" emacs-version)
+                                                  elpaca-directory))
 (defvar elpaca-sources-directory (expand-file-name "sources/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                               :ref nil :depth 1 :inherit ignore


### PR DESCRIPTION
A separate build directory for each Emacs version ensures that Emacs will never read outdated bytecode based on built-in code from another Emacs version. For example, the transition from 30 to 31 includes an internal change to `define-globalized-minor-mode` that makes it incompatible with bytecode compiled for Emacs 30.
